### PR TITLE
queue-with-retry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "phpunit/phpunit": "4.2.*",
         "mockery/mockery": "0.9.*",
-        "illuminate/queue": "4.*"
+        "illuminate/queue": "5.*"
     },
     "suggest": {
         "illuminate/support": "Required for Laravel support"

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -1,518 +1,575 @@
-<?php namespace Maknz\Slack;
+<?php
+namespace Maknz\Slack;
 
 use InvalidArgumentException;
 
-class Attachment {
-  
-  /**
-   * The fallback text to use for clients that don't support attachments
-   *
-   * @var string
-   */
-  protected $fallback;
+class Attachment
+{
+    /**
+      * The fallback text to use for clients that don't support attachments
+      *
+      * @var string
+      */
+    protected $fallback;
 
-  /**
-   * Optional text that should appear within the attachment
-   *
-   * @var string
-   */
-  protected $text;
+    /**
+     * Optional text that should appear within the attachment
+     *
+     * @var string
+     */
+    protected $text;
 
-  /**
-   * Optional image that should appear within the attachment
-   *
-   * @var string
-   */
-  protected $image_url;
-  
-  /**
-    * Optional thumbnail that should appear within the attachment
-    *
-    * @var string 
+    /**
+     * Optional image that should appear within the attachment
+     *
+     * @var string
+     */
+    protected $imageUrl;
+
+    /**
+     * Optional thumbnail that should appear within the attachment
+     *
+     * @var string
+     */
+    protected $thumbUrl;
+
+    /**
+     * Optional text that should appear above the formatted data
+     *
+     * @var string
+     */
+    protected $pretext;
+
+    /**
+     * Optional title for the attachment
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * Optional title link for the attachment
+     *
+     * @var string
+     */
+    protected $titleLink;
+
+    /**
+    * Optional author name for the attachment
+     *
+     * @var string
+     */
+    protected $authorName;
+
+    /**
+     * Optional author link for the attachment
+     *
+     * @var string
+     */
+    protected $authorLink;
+
+    /**
+     * Optional author icon for the attachment
+     *
+     * @var string
+     */
+    protected $authorIcon;
+
+    /**
+     * The color to use for the attachment
+     *
+     * @var string
+     */
+    protected $color = 'good';
+
+    /**
+     * The fields of the attachment
+     *
+     * @var array
+     */
+    protected $fields = [];
+
+    /**
+     * The fields of the attachment that Slack should interpret
+     * with its Markdown-like language
+     *
+     * @var array
+     */
+    protected $markdownFields = [];
+
+    /**
+     * Instantiate a new Attachment
+     *
+     * @param array $attributes
+     *
+     * @return void
+     */
+    public function __construct(array $attributes)
+    {
+        if (isset($attributes['fallback']))
+        {
+            $this->setFallback($attributes['fallback']);
+        }
+
+        if (isset($attributes['text']))
+        {
+            $this->setText($attributes['text']);
+        }
+
+        if (isset($attributes['image_url']))
+        {
+            $this->setImageUrl($attributes['image_url']);
+        }
+
+        if (isset($attributes['thumb_url']))
+        {
+            $this->setThumbUrl($attributes['thumb_url']);
+        }
+
+        if (isset($attributes['pretext']))
+        {
+            $this->setPretext($attributes['pretext']);
+        }
+
+        if (isset($attributes['color']))
+        {
+            $this->setColor($attributes['color']);
+        }
+
+        if (isset($attributes['fields']))
+        {
+            $this->setFields($attributes['fields']);
+        }
+
+        if (isset($attributes['mrkdwn_in']))
+        {
+            $this->setMarkdownFields($attributes['mrkdwn_in']);
+        }
+
+        if (isset($attributes['title']))
+        {
+            $this->setTitle($attributes['title']);
+        }
+
+        if (isset($attributes['title_link']))
+        {
+            $this->setTitleLink($attributes['title_link']);
+        }
+
+        if (isset($attributes['author_name']))
+        {
+            $this->setAuthorName($attributes['author_name']);
+        }
+
+        if (isset($attributes['author_link']))
+        {
+            $this->setAuthorLink($attributes['author_link']);
+        }
+
+        if (isset($attributes['author_icon']))
+        {
+            $this->setAuthorIcon($attributes['author_icon']);
+        }
+    }
+
+    /**
+     * Get the fallback text
+     *
+     * @return string
+     */
+    public function getFallback()
+    {
+        return $this->fallback;
+    }
+
+    /**
+     * Set the fallback text
+     *
+     * @param string $fallback fallback text
+     *
+     * @return $this
+     */
+    public function setFallback($fallback)
+    {
+        $this->fallback = $fallback;
+
+        return $this;
+    }
+
+    /**
+     * Get the optional text to appear within the attachment
+     *
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * Set the optional text to appear within the attachment
+     *
+     * @param string $text text
+     *
+     * @return $this
+     */
+    public function setText($text)
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * Get the optional image to appear within the attachment
+     *
+     * @return string
+     */
+    public function getImageUrl()
+    {
+        return $this->imageUrl;
+    }
+
+    /**
+     * Set the optional image to appear within the attachment
+     *
+     * @param string $imageUrl iamge url
+     *
+     * @return $this
     */
-  protected $thumb_url;
-
-  /**
-   * Optional text that should appear above the formatted data
-   *
-   * @var string
-   */
-  protected $pretext;
-
-  /**
-   * Optional title for the attachment
-   *
-   * @var string
-   */
-  protected $title;
-
-  /**
-   * Optional title link for the attachment
-   *
-   * @var string
-   */
-  protected $title_link;
-  
-  /**
-   * Optional author name for the attachment
-   *
-   * @var string
-   */
-  protected $author_name;
-
-  /**
-   * Optional author link for the attachment
-   *
-   * @var string
-   */
-  protected $author_link;
-
-  /**
-   * Optional author icon for the attachment
-   *
-   * @var string
-   */
-  protected $author_icon;
-
-  /**
-   * The color to use for the attachment
-   *
-   * @var string
-   */
-  protected $color = 'good';
-
-  /**
-   * The fields of the attachment
-   *
-   * @var array
-   */
-  protected $fields = [];
-
-  /**
-   * The fields of the attachment that Slack should interpret
-   * with its Markdown-like language
-   *
-   * @var array
-   */
-  protected $markdown_fields = [];
-
-  /**
-   * Instantiate a new Attachment
-   *
-   * @param array $attributes
-   * @return void
-   */
-  public function __construct(array $attributes)
-  {
-    if (isset($attributes['fallback'])) $this->setFallback($attributes['fallback']);
-
-    if (isset($attributes['text'])) $this->setText($attributes['text']);
-
-    if (isset($attributes['image_url'])) $this->setImageUrl($attributes['image_url']);
-    
-    if (isset($attributes['thumb_url'])) $this->setThumbUrl($attributes['thumb_url']);
-
-    if (isset($attributes['pretext'])) $this->setPretext($attributes['pretext']);
-
-    if (isset($attributes['color'])) $this->setColor($attributes['color']);
-
-    if (isset($attributes['fields'])) $this->setFields($attributes['fields']);
-
-    if (isset($attributes['mrkdwn_in'])) $this->setMarkdownFields($attributes['mrkdwn_in']);
-
-    if (isset($attributes['title'])) $this->setTitle($attributes['title']);
-
-    if (isset($attributes['title_link'])) $this->setTitleLink($attributes['title_link']);
-    
-    if (isset($attributes['author_name'])) $this->setAuthorName($attributes['author_name']);
-
-    if (isset($attributes['author_link'])) $this->setAuthorLink($attributes['author_link']);
-
-    if (isset($attributes['author_icon'])) $this->setAuthorIcon($attributes['author_icon']);
-  }
-
-  /**
-   * Get the fallback text
-   *
-   * @return string
-   */
-  public function getFallback()
-  {
-    return $this->fallback;
-  }
-
-  /**
-   * Set the fallback text
-   *
-   * @param string $fallback
-   * @return $this
-   */
-  public function setFallback($fallback)
-  {
-    $this->fallback = $fallback;
-
-    return $this;
-  }
-
-  /**
-   * Get the optional text to appear within the attachment
-   *
-   * @return string
-   */
-  public function getText()
-  {
-    return $this->text;
-  }
-
-  /**
-   * Set the optional text to appear within the attachment
-   *
-   * @param string $text
-   * @return $this
-   */
-  public function setText($text)
-  {
-    $this->text = $text;
-
-    return $this;
-  }
-
-  /**
-   * Get the optional image to appear within the attachment
-   *
-   * @return string
-   */
-  public function getImageUrl()
-  {
-    return $this->image_url;
-  }
-
-  /**
-   * Set the optional image to appear within the attachment
-   *
-   * @param string $image_url
-   * @return $this
-   */
-  public function setImageUrl($image_url)
-  {
-    $this->image_url = $image_url;
-
-    return $this;
-  }
-  
-  /**
-   * Get the optional thumbnail to appear within the attachment
-   *
-   * @return string
-   */
-  public function getThumbUrl()
-  {
-    return $this->thumb_url;
-  }
-
-  /**
-   * Set the optional thumbnail to appear within the attachment
-   *
-   * @param string $thumb_url
-   * @return $this
-   */
-  public function setThumbUrl($thumb_url)
-  {
-    $this->thumb_url = $thumb_url;
-
-    return $this;
-  }
-
-  /**
-   * Get the text that should appear above the formatted data
-   *
-   * @return string
-   */
-  public function getPretext()
-  {
-    return $this->pretext;
-  }
-
-  /**
-   * Set the text that should appear above the formatted data
-   *
-   * @param string $pretext
-   * @return $this
-   */
-  public function setPretext($pretext)
-  {
-    $this->pretext = $pretext;
-
-    return $this;
-  }
-
-  /**
-   * Get the color to use for the attachment
-   *
-   * @return string
-   */
-  public function getColor()
-  {
-    return $this->color;
-  }
-
-  /**
-   * Set the color to use for the attachment
-   *
-   * @param string $colour
-   * @return void
-   */
-  public function setColor($color)
-  {
-    $this->color = $color;
-
-    return $this;
-  }
-
-  /**
-   * Get the title to use for the attachment
-   *
-   * @return string
-   */
-  public function getTitle()
-  {
-      return $this->title;
-  }
-
-  /**
-   * Set the title to use for the attachment
-   *
-   * @param string $title
-   * @return void
-   */
-  public function setTitle($title)
-  {
-      $this->title = $title;
-
-      return $this;
-  }
-
-  /**
-   * Get the title link to use for the attachment
-   *
-   * @return string
-   */
-  public function getTitleLink()
-  {
-        return $this->title_link;
-  }
-
-  /**
-   * Set the title link to use for the attachment
-   *
-   * @param string $title_link
-   * @return void
-   */
-  public function setTitleLink($title_link)
-  {
-      $this->title_link = $title_link;
-
-      return $this;
-  }
-
-  /**
-   * Get the author name to use for the attachment
-   *
-   * @return string
-   */
-  public function getAuthorName()
-  {
-    return $this->author_name;
-  }
-
-  /**
-   * Set the author name to use for the attachment
-   *
-   * @param string $author_name
-   * @return void
-   */
-  public function setAuthorName($author_name)
-  {
-    $this->author_name = $author_name;
-
-    return $this;
-  }
-
-  /**
-   * Get the author link to use for the attachment
-   *
-   * @return string
-   */
-  public function getAuthorLink()
-  {
-    return $this->author_link;
-  }
-
-  /**
-   * Set the auhtor link to use for the attachment
-   *
-   * @param string $author_link
-   * @return void
-   */
-  public function setAuthorLink($author_link)
-  {
-    $this->author_link = $author_link;
-
-    return $this;
-  }
-
-  /**
-   * Get the author icon to use for the attachment
-   *
-   * @return string
-   */
-  public function getAuthorIcon()
-  {
-    return $this->author_icon;
-  }
-
-  /**
-   * Set the author icon to use for the attachment
-   *
-   * @param string $author_icon
-   * @return void
-   */
-  public function setAuthorIcon($author_icon)
-  {
-    $this->author_icon = $author_icon;
-
-    return $this;
-  }
-  /**
-   * Get the fields for the attachment
-   *
-   * @return array
-   */
-  public function getFields()
-  {
-    return $this->fields;
-  }
-
-  /**
-   * Set the fields for the attachment
-   *
-   * @param array $fields
-   * @return void
-   */
-  public function setFields(array $fields)
-  {
-    $this->clearFields();
-
-    foreach ($fields as $field)
+    public function setImageUrl($imageUrl)
     {
-      $this->addField($field);
+        $this->imageUrl = $imageUrl;
+
+        return $this;
     }
 
-    return $this;
-  }
-
-  /**
-   * Add a field to the attachment
-   *
-   * @param mixed $field
-   * @return $this
-   */
-  public function addField($field)
-  {
-    if ($field instanceof AttachmentField)
+    /**
+     * Get the optional thumbnail to appear within the attachment
+     *
+     * @return string
+     */
+    public function getThumbUrl()
     {
-      $this->fields[] = $field;
-
-      return $this;
+        return $this->thumbUrl;
     }
 
-    elseif (is_array($field))
+    /**
+     * Set the optional thumbnail to appear within the attachment
+     *
+     * @param string $thumbUrl thumb url
+     *
+     * @return $this
+    */
+    public function setThumbUrl($thumbUrl)
     {
-      $this->fields[] = new AttachmentField($field);
+        $this->thumbUrl = $thumbUrl;
 
-      return $this;
+        return $this;
     }
 
-    throw new InvalidArgumentException('The attachment field must be an instance of Maknz\Slack\AttachmentField or a keyed array');
-  }
+    /**
+     * Get the text that should appear above the formatted data
+     *
+     * @return string
+     */
+    public function getPretext()
+    {
+        return $this->pretext;
+    }
 
-  /**
-   * Clear the fields for the attachment
-   *
-   * @return $this
-   */
-  public function clearFields()
-  {
-    $this->fields = [];
+    /**
+     * Set the text that should appear above the formatted data
+     *
+     * @param string $pretext pretext
+     *
+     * @return $this
+     */
+    public function setPretext($pretext)
+    {
+        $this->pretext = $pretext;
 
-    return $this;
-  }
+        return $this;
+    }
 
-  /**
-   * Get the fields Slack should interpret in its
-   * Markdown-like language
-   *
-   * @return array
-   */
-  public function getMarkdownFields()
-  {
-    return $this->markdown_fields;
-  }
+    /**
+     * Get the color to use for the attachment
+     *
+     * @return string
+     */
+    public function getColor()
+    {
+        return $this->color;
+    }
 
-  /**
-   * Set the fields Slack should interpret in its
-   * Markdown-like language
-   *
-   * @param array $fields
-   * @return $this
-   */
-  public function setMarkdownFields(array $fields)
-  {
-    $this->markdown_fields = $fields;
+    /**
+     * Set the color to use for the attachment
+     *
+     * @param string $color color
+     *
+     * @return $this
+     */
+    public function setColor($color)
+    {
+        $this->color = $color;
 
-    return $this;
-  }
+        return $this;
+    }
 
-  /**
-   * Convert this attachment to its array representation
-   *
-   * @return array
-   */
-  public function toArray()
-  {
-    $data = [
-      'fallback' => $this->getFallback(),
-      'text' => $this->getText(),
-      'pretext' => $this->getPretext(),
-      'color' => $this->getColor(),
-      'mrkdwn_in' => $this->getMarkdownFields(),
-      'image_url' => $this->getImageUrl(),
-      'thumb_url' => $this->getThumbUrl(),
-      'title' => $this->getTitle(),
-      'title_link' => $this->getTitleLink(),
-      'author_name' => $this->getAuthorName(),
-      'author_link' => $this->getAuthorLink(),
-      'author_icon' => $this->getAuthorIcon()
-    ];
+    /**
+     * Get the title to use for the attachment
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
 
-    $data['fields'] = $this->getFieldsAsArrays();
+    /**
+     * Set the title to use for the attachment
+     *
+     * @param string $title title
+     *
+     * @return $this
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
 
-    return $data;
-  }
+        return $this;
+    }
 
-  /**
-   * Iterates over all fields in this attachment and returns
-   * them in their array form
-   *
-   * @return array
-   */
-  protected function getFieldsAsArrays()
-  {
-    $fields = [];
+    /**
+     * Get the title link to use for the attachment
+     *
+     * @return string
+     */
+    public function getTitleLink()
+    {
+        return $this->titleLink;
+    }
 
-    foreach ($this->getFields() as $field) $fields[] = $field->toArray();
+    /**
+    * Set the title link to use for the attachment
+    *
+    * @param string $titleLink title link
+    *
+    * @return $this
+    */
+    public function setTitleLink($titleLink)
+    {
+        $this->titleLink = $titleLink;
 
-    return $fields;
-  }
+        return $this;
+    }
 
+    /**
+     * Get the author name to use for the attachment
+     *
+     * @return string
+     */
+    public function getAuthorName()
+    {
+        return $this->authorName;
+    }
+
+    /**
+     * Set the author name to use for the attachment
+     *
+     * @param string $authorName author name
+     *
+     * @return void
+     */
+    public function setAuthorName($authorName)
+    {
+        $this->authorName = $authorName;
+
+        return $this;
+    }
+
+    /**
+     * Get the author link to use for the attachment
+     *
+     * @return string
+     */
+    public function getAuthorLink()
+    {
+        return $this->authorLink;
+    }
+
+    /**
+     * Set the auhtor link to use for the attachment
+     *
+     * @param string $authorLink authorlink
+     *
+     * @return void
+    */
+    public function setAuthorLink($authorLink)
+    {
+        $this->authorLink = $authorLink;
+
+        return $this;
+    }
+
+    /**
+     * Get the author icon to use for the attachment
+     *
+     * @return string
+     */
+    public function getAuthorIcon()
+    {
+        return $this->authorIcon;
+    }
+
+    /**
+    * Set the author icon to use for the attachment
+    *
+    * @param string $authorIcon author icon
+    *
+    * @return void
+    */
+    public function setAuthorIcon($authorIcon)
+    {
+        $this->authorIcon = $authorIcon;
+
+        return $this;
+    }
+
+    /**
+     * Get the fields for the attachment
+     *
+     * @return array
+     */
+    public function getFields()
+    {
+        return $this->fields;
+    }
+
+    /**
+     * Set the fields for the attachment
+     *
+     * @param array $fields fields
+     *
+     * @return void
+    */
+    public function setFields(array $fields)
+    {
+        $this->clearFields();
+
+        foreach ($fields as $field)
+        {
+            $this->addField($field);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a field to the attachment
+     *
+     * @param mixed $field fields
+     *
+     * @return $this
+    */
+    public function addField($field)
+    {
+        if ($field instanceof AttachmentField)
+        {
+            $this->fields[] = $field;
+        }
+        else if (is_array($field))
+        {
+            $this->fields[] = new AttachmentField($field);
+        }
+        else
+        {
+            throw new InvalidArgumentException(
+                'The attachment field must be an instance of Maknz\Slack\AttachmentField or a keyed array');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clear the fields for the attachment
+     *
+     * @return $this
+     */
+    public function clearFields()
+    {
+        $this->fields = [];
+
+        return $this;
+    }
+
+    /**
+     * Get the fields Slack should interpret in its
+     * Markdown-like language
+     *
+     * @return array
+     */
+    public function getMarkdownFields()
+    {
+        return $this->markdownFields;
+    }
+
+    /**
+     * Set the fields Slack should interpret in its
+     * Markdown-like language
+     *
+     * @param array $fields fields
+     *
+     * @return $this
+     */
+    public function setMarkdownFields(array $fields)
+    {
+        $this->markdownFields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * Convert this attachment to its array representation
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $data = [
+            'fallback'   => $this->getFallback(),
+            'text'       => $this->getText(),
+            'pretext'    => $this->getPretext(),
+            'color'      => $this->getColor(),
+            'mrkdwnIn'   => $this->getMarkdownFields(),
+            'imageUrl'   => $this->getImageUrl(),
+            'thumbUrl'   => $this->getThumbUrl(),
+            'title'      => $this->getTitle(),
+            'titleLink'  => $this->getTitleLink(),
+            'authorName' => $this->getAuthorName(),
+            'authorLink' => $this->getAuthorLink(),
+            'authorIcon' => $this->getAuthorIcon(),
+            'fields'     => $this->getFieldsAsArrays()
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Iterates over all fields in this attachment and returns
+     * them in their array form
+     *
+     * @return array
+     */
+    protected function getFieldsAsArrays()
+    {
+        $fields = [];
+
+        foreach ($this->getFields() as $field)
+        {
+            $fields[] = $field->toArray();
+        }
+
+        return $fields;
+    }
 }

--- a/src/AttachmentField.php
+++ b/src/AttachmentField.php
@@ -1,127 +1,144 @@
-<?php namespace Maknz\Slack;
+<?php
 
-class AttachmentField {
-  
-  /**
-   * The required title field of the field
-   *
-   * @var string
-   */
-  protected $title;
+namespace Maknz\Slack;
 
-  /**
-   * The required value of the field
-   *
-   * @var string
-   */
-  protected $value;
+class AttachmentField
+{
 
-  /**
-   * Whether the value is short enough to fit side by side with
-   * other values
-   *
-   * @var boolean
-   */
-  protected $short = false;
+    /**
+     * The required title field of the field
+     *
+     * @var string
+     */
+    protected $title;
 
-  /**
-   * Instantiate a new AttachmentField
-   *
-   * @param array $attributes
-   * @return void
-   */
-  public function __construct(array $attributes)
-  {
-    if (isset($attributes['title'])) $this->setTitle($attributes['title']);
+    /**
+     * The required value of the field
+     *
+     * @var string
+     */
+    protected $value;
 
-    if (isset($attributes['value'])) $this->setValue($attributes['value']);
+    /**
+    * Whether the value is short enough to fit side by side with
+     * other values
+     *
+     * @var boolean
+     */
+    protected $short = false;
 
-    if (isset($attributes['short'])) $this->setShort($attributes['short']);
-  }
+    /**
+    * Instantiate a new AttachmentField
+     *
+     * @param array $attributes attributes
+     *
+     * @return void
+    */
+    public function __construct(array $attributes)
+    {
+        if (isset($attributes['title']))
+        {
+            $this->setTitle($attributes['title']);
+        }
 
-  /**
-   * Get the title of the field
-   *
-   * @return string
-   */
-  public function getTitle()
-  {
-    return $this->title;
-  }
+        if (isset($attributes['value']))
+        {
+            $this->setValue($attributes['value']);
+        }
 
-  /**
-   * Set the title of the field
-   *
-   * @param string $title
-   * @return $this
-   */
-  public function setTitle($title)
-  {
-    $this->title = $title;
+        if (isset($attributes['short']))
+        {
+            $this->setShort($attributes['short']);
+        }
+    }
 
-    return $this;
-  }
+    /**
+     * Get the title of the field
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
 
-  /**
-   * Get the value of the field
-   *
-   * @return string
-   */
-  public function getValue()
-  {
-    return $this->value;
-  }
+    /**
+     * Set the title of the field
+     *
+     * @param string $title title
+     *
+     * @return $this
+    */
+    public function setTitle($title)
+    {
+        $this->title = $title;
 
-  /**
-   * Set the value of the field
-   *
-   * @param string $value
-   * @return $this
-   */
-  public function setValue($value)
-  {
-    $this->value = $value;
+        return $this;
+    }
 
-    return $this;
-  }
+    /**
+     * Get the value of the field
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
 
-  /**
-   * Get whether this field is short enough for displaying
-   * side-by-side with other fields
-   *
-   * @return boolean
-   */
-  public function getShort()
-  {
-    return $this->short;
-  }
+    /**
+     * Set the value of the field
+      *
+     * @param string $value value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
 
-  /**
-   * Set whether this field is short enough for displaying
-   * side-by-side with other fields
-   *
-   * @param string $value
-   * @return $this
-   */
-  public function setShort($value)
-  {
-    $this->short = (boolean) $value;
+        return $this;
+    }
 
-    return $this;
-  }
+    /**
+     * Get whether this field is short enough for displaying
+     * side-by-side with other fields
+     *
+     * @return boolean
+     */
+    public function getShort()
+    {
+        return $this->short;
+    }
 
-  /**
-   * Get the array representation of this attachment field
-   *
-   * @return array
-   */
-  public function toArray()
-  {
-    return [
-      'title' => $this->getTitle(),
-      'value' => $this->getValue(),
-      'short' => $this->getShort()
-    ];
-  }
+    /**
+     * Set whether this field is short enough for displaying
+     * side-by-side with other fields
+     *
+     * @param string $value value
+     *
+     * @return $this
+     */
+    public function setShort($value)
+    {
+        $this->short = (boolean) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of this attachment field
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+
+        return [
+            'title' => $this->getTitle(),
+            'value' => $this->getValue(),
+            'short' => $this->getShort()
+        ];
+    }
 
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -392,8 +392,7 @@ class Client {
    *                                                different for different client calls between syncronous and
    *                                                asynchronous calls
    */
-
-  protected function guzzlePoster($data)
+  protected function messagePoster($data)
   {
     $encoded = json_encode($data, JSON_UNESCAPED_UNICODE);
 
@@ -410,7 +409,7 @@ class Client {
   {
     $payload = $this->preparePayload($message);
 
-    $this->guzzlePoster($payload);
+    $this->messagePoster($payload);
   }
 
   /**
@@ -422,7 +421,10 @@ class Client {
   public function queueMessage(Message $message, $numRetries)
   {
     // check for malicious calls and if so, try max times
-    if ($numRetries <= 0) $numRetries = self::MAX_RETRY_ATTEMPTS;
+    if ($numRetries <= 0)
+    {
+        $numRetries = self::MAX_RETRY_ATTEMPTS;
+    }
 
     $payload = $this->preparePayload($message, $numRetries);
 
@@ -441,18 +443,17 @@ class Client {
   {
     if($job->attempts() >= $data['num_retries'])
     {
-      $job->delete();
+        $job->delete();
     }
 
     try
     {
-        $this->guzzlePoster($data);
+        $this->messagePoster($data);
 
         $job->delete();
 
         $isMessageSent = true;
     }
-
     catch(ClientException $e)
     {
         $job->release(self::RELEASE_WAIT_TIMEOUT);
@@ -477,11 +478,14 @@ class Client {
       'mrkdwn' => $message->getAllowMarkdown()
     ];
 
-    if($numRetries) $payload['num_retries'] = $numRetries;
+    if($numRetries)
+    {
+        $payload['num_retries'] = $numRetries;
+    }
 
     if ($icon = $message->getIcon())
     {
-      $payload[$message->getIconType()] = $icon;
+        $payload[$message->getIconType()] = $icon;
     }
 
     $payload['attachments'] = $this->getAttachmentsAsArrays($message);

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,558 +1,614 @@
-<?php namespace Maknz\Slack;
+<?php
+
+namespace Maknz\Slack;
 
 use GuzzleHttp\Client as Guzzle;
 use Illuminate\Queue\Capsule\Manager as Queue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use GuzzleHttp\Exception\ClientException;
 
-class Client {
-
-  /**
-   * The Slack incoming webhook endpoint
-   *
-   * @var string
-   */
-  protected $endpoint;
-
-  /**
-   * The default channel to send messages to
-   *
-   * @var string
-   */
-  protected $channel;
-
-  /**
-   * The default username to send messages as
-   *
-   * @var string
-   */
-  protected $username;
-
-  /**
-   * The default icon to send messages with
-   *
-   * @var string
-   */
-  protected $icon;
-
-  /**
-   * Whether to link names like @regan or leave
-   * them as plain text
-   *
-   * @var boolean
-   */
-  protected $link_names = false;
-
-  /**
-   * Whether Slack should unfurl text-based URLs
-   *
-   * @var boolean
-   */
-  protected $unfurl_links = false;
-
-  /**
-   * Whether Slack should unfurl media URLs
-   *
-   * @var boolean
-   */
-  protected $unfurl_media = true;
-
-  /**
-   * Whether message text should be formatted with Slack's
-   * Markdown-like language
-   *
-   * @var boolean
-   */
-  protected $allow_markdown = true;
-
-  /**
-   * The attachment fields which should be formatted with
-   * Slack's Markdown-like language
-   *
-   * @var array
-   */
-  protected $markdown_in_attachments = [];
-
-
-  /**
-   * The Guzzle HTTP client instance
-   *
-   * @var \GuzzleHttp\Client
-   */
-  protected $guzzle;
-
-  /**
-   * The QueueManager instance
-   * @var Illuminate\Queue\QueueManager
-   */
-  protected $queue;
-
-  /**
-   * Slack Enable mode
-   * @var boolean
-   */
-  protected $slackStatus = true;
-
-
-  /**
-   * Queue wait timeout on releasing the job. Ideally, for a more complicated scenario
-   * the wait timeout could increase based on the number of failures. But we
-   * are not handling such cases here.
-   *
-   * @var integer
-   */
-  const RELEASE_WAIT_TIMEOUT = 120;
-
-  /**
-   * Number of retries before giving up on the job.
-   *
-   * @var integer
-   */
-  const MAX_RETRY_ATTEMPTS = 10;
-
-
-  /**
-   * Instantiate a new Client
-   *
-   * @param string $endpoint
-   * @param array $attributes
-   * @return void
-   */
-  public function __construct($endpoint, array $attributes = [],QueueContract $queue = null, Guzzle $guzzle = null)
-  {
-    $this->endpoint = $endpoint;
-
-    if (isset($attributes['channel'])) $this->setDefaultChannel($attributes['channel']);
-
-    if (isset($attributes['username'])) $this->setDefaultUsername($attributes['username']);
-
-    if (isset($attributes['icon'])) $this->setDefaultIcon($attributes['icon']);
-
-    if (isset($attributes['link_names'])) $this->setLinkNames($attributes['link_names']);
-
-    if (isset($attributes['unfurl_links'])) $this->setUnfurlLinks($attributes['unfurl_links']);
-
-    if (isset($attributes['unfurl_media'])) $this->setUnfurlMedia($attributes['unfurl_media']);
-
-    if (isset($attributes['allow_markdown'])) $this->setAllowMarkdown($attributes['allow_markdown']);
-
-    if (isset($attributes['markdown_in_attachments'])) $this->setMarkdownInAttachments($attributes['markdown_in_attachments']);
-
-    if(isset($attributes['is_slack_enabled'])) $this->setSlackStatus($attributes['is_slack_enabled']);
-
-    $this->guzzle = $guzzle ?: new Guzzle;
-
-    $this->queue = $queue;
-
-    $this->maxRetryAttempts = self::MAX_RETRY_ATTEMPTS;
-  }
-
-  /**
-   * Sets the queue to be used
-   * @param string $queue Name of the queue
-   * @return $this
-   */
-  public function setQueue(QueueManager $queue)
-  {
-    $this->queue = $queue;
-
-    return $this;
-  }
-
-  /**
-   * Get the queue to be used
-   *
-   * @return string
-   */
-  public function getQueue()
-  {
-    return $this->queue;
-  }
-  /**
-   * Pass any unhandled methods through to a new Message
-   * instance
-   *
-   * @param string $name The name of the method
-   * @param array $arguments The method arguments
-   * @return \Maknz\Slack\Message
-   */
-  public function __call($name, $arguments)
-  {
-    $message = $this->createMessage();
-
-    call_user_func_array([$message, $name], $arguments);
-
-    return $message;
-  }
-
-  /**
-   * Get the Slack endpoint
-   *
-   * @return string
-   */
-  public function getEndpoint()
-  {
-    return $this->endpoint;
-  }
-
-  /**
-   * Set the Slack endpoint
-   *
-   * @param string $endpoint
-   * @return void
-   */
-  public function setEndpoint($endpoint)
-  {
-    $this->endpoint = $endpoint;
-  }
-
-  /**
-   * Get the default channel messages will be created for
-   *
-   * @return string
-   */
-  public function getDefaultChannel()
-  {
-    return $this->channel;
-  }
-
-  /**
-   * Set the default channel messages will be created for
-   *
-   * @param string $channel
-   * @return void
-   */
-  public function setDefaultChannel($channel)
-  {
-    $this->channel = $channel;
-  }
-
-  /**
-   * Get the default username messages will be created for
-   *
-   * @return string
-   */
-  public function getDefaultUsername()
-  {
-    return $this->username;
-  }
-
-  /**
-   * Set the default username messages will be created for
-   *
-   * @param string $username
-   * @return void
-   */
-  public function setDefaultUsername($username)
-  {
-    $this->username = $username;
-  }
-
-  /**
-   * Get the default icon messages will be created with
-   *
-   * @return string
-   */
-  public function getDefaultIcon()
-  {
-    return $this->icon;
-  }
-
-  /**
-   * Set the default icon messages will be created with
-   *
-   * @param string $icon
-   * @return void
-   */
-  public function setDefaultIcon($icon)
-  {
-    $this->icon = $icon;
-  }
-
-  /**
-   * Get whether messages sent will have names (like @regan)
-   * will be converted into links
-   *
-   * @return boolean
-   */
-  public function getLinkNames()
-  {
-    return $this->link_names;
-  }
-
-  /**
-   * Returns the QueueManager instance being used
-   * @return Illuminate\Queue\QueueManager
-   */
-  public function getQueueManager()
-  {
-    return $this->queue;
-  }
-
-  /**
-   * Set whether messages sent will have names (like @regan)
-   * will be converted into links
-   *
-   * @param boolean $value
-   * @return void
-   */
-  public function setLinkNames($value)
-  {
-    $this->link_names = (boolean) $value;
-  }
-
-  /**
-   * Get whether text links should be unfurled
-   *
-   * @return boolean
-   */
-  public function getUnfurlLinks()
-  {
-    return $this->unfurl_links;
-  }
-
-  /**
-   * Set whether text links should be unfurled
-   *
-   * @param boolean $value
-   * @return void
-   */
-  public function setUnfurlLinks($value)
-  {
-    $this->unfurl_links = (boolean) $value;
-  }
-
-  /**
-   * Get whether media links should be unfurled
-   *
-   * @return boolean
-   */
-  public function getUnfurlMedia()
-  {
-    return $this->unfurl_media;
-  }
-
-  /**
-   * Set whether media links should be unfurled
-   *
-   * @param boolean $value
-   * @return void
-   */
-  public function setUnfurlMedia($value)
-  {
-    $this->unfurl_media = (boolean) $value;
-  }
-
-  /**
-   * Get whether message text should be formatted with
-   * Slack's Markdown-like language
-   *
-   * @return boolean
-   */
-  public function getAllowMarkdown()
-  {
-    return $this->allow_markdown;
-  }
-
-  /**
-   * Set whether message text should be formatted with
-   * Slack's Markdown-like language
-   *
-   * @param boolean $value
-   * @return void
-   */
-  public function setAllowMarkdown($value)
-  {
-    $this->allow_markdown = (boolean) $value;
-  }
-
-  /**
-   * Get the attachment fields which should be formatted
-   * in Slack's Markdown-like language
-   *
-   * @return array
-   */
-  public function getMarkdownInAttachments()
-  {
-    return $this->markdown_in_attachments;
-  }
-
-  /**
-   * Set the attachment fields which should be formatted
-   * in Slack's Markdown-like language
-   *
-   * @param array $fields
-   * @return void
-   */
-  public function setMarkdownInAttachments(array $fields)
-  {
-    $this->markdown_in_attachments = $fields;
-  }
-
-  /**
-   * Set whether slack mode is enabled/disabled
-   *
-   * @param boolean $status
-   * @return void
-   */
-  public function setSlackStatus($status)
-  {
-    $this->slackStatus = $status;
-  }
-
-  /**
-   * Gets the current slack mode - enabled/disabled
-   *
-   * @return boolean
-   */
-  public function getSlackStatus()
-  {
-    return $this->slackStatus;
-  }
-
-  /**
-   * Create a new message with defaults
-   *
-   * @return \Maknz\Slack\Message
-   */
-  public function createMessage()
-  {
-    $message = new Message($this);
-
-    $message->setChannel($this->getDefaultChannel());
-
-    $message->setUsername($this->getDefaultUsername());
-
-    $message->setIcon($this->getDefaultIcon());
-
-    $message->setAllowMarkdown($this->getAllowMarkdown());
-
-    $message->setMarkdownInAttachments($this->getMarkdownInAttachments());
-
-    return $message;
-  }
-
-  /**
-   * Actually send the message
-   * @param  array            $data                 Slack Payload
-   * @return void
-   * @throws GuzzleHttp\Exception\ClientException   throws exception due to network errors. The client/caller
-   *                                                needs to handle this as the resulting behavior might be
-   *                                                different for different client calls between syncronous and
-   *                                                asynchronous calls
-   */
-  protected function messagePoster($data)
-  {
-    $encoded = json_encode($data, JSON_UNESCAPED_UNICODE);
-
-    $this->guzzle->post($this->endpoint, ['body' => $encoded]);
-  }
-
-  /**
-   * Send a message
-   *
-   * @param \Maknz\Slack\Message $message
-   * @return void
-   */
-  public function sendMessage(Message $message)
-  {
-    $payload = $message->getPayload();
-
-    $this->messagePoster($payload);
-  }
-
-  /**
-   * Queue a message
-   *
-   * @param \Maknz\Slack\Message $message
-   * @return void
-   */
-  public function queueMessage(Message $message, $numRetries)
-  {
-
-    $payload = $message->getPayload();
-
-    $this->maxRetryAttempts = $numRetries;
-
-    $this->queue->push(__CLASS__, $payload);
-  }
-
-  /**
-   * Execute the message sending via a Queue
-   * @param  Illuminate\Queue\Jobs\Job $job Job instance
-   * @param  array $data Slack Payload
-   * @return void
-   */
-  public function fire($job, array $data)
-  {
-    if($job->attempts() >= $data['metadata']['num_retries'])
+class Client
+{
+
+    /**
+     * The Slack incoming webhook endpoint
+     *
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * The default channel to send messages to
+     *
+     * @var string
+     */
+    protected $channel;
+
+    /**
+     * The default username to send messages as
+     *
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * The default icon to send messages with
+     *
+     * @var string
+     */
+    protected $icon;
+
+    /**
+     * Whether to link names like @regan or leave
+     * them as plain text
+     *
+     * @var boolean
+     */
+    protected $link_names = false;
+
+    /**
+     * Whether Slack should unfurl text-based URLs
+     *
+     * @var boolean
+     */
+    protected $unfurl_links = false;
+
+    /**
+     * Whether Slack should unfurl media URLs
+     *
+     * @var boolean
+     */
+    protected $unfurl_media = true;
+
+    /**
+     * Whether message text should be formatted with Slack's
+     * Markdown-like language
+     *
+     * @var boolean
+     */
+    protected $allow_markdown = true;
+
+    /**
+     * The attachment fields which should be formatted with
+     * Slack's Markdown-like language
+     *
+     * @var array
+     */
+    protected $markdown_in_attachments = [];
+
+
+    /**
+     * The Guzzle HTTP client instance
+     *
+     * @var \GuzzleHttp\Client
+     */
+    protected $guzzle;
+
+    /**
+     * The QueueManager instance
+     *
+     * @var Illuminate\Queue\QueueManager
+     */
+    protected $queue;
+
+    /**
+     * Slack Enable mode
+     * @var boolean
+     */
+    protected $slackStatus = true;
+
+
+    /**
+     * Queue wait timeout on releasing the job. Ideally, for a more complicated scenario
+     * the wait timeout could increase based on the number of failures. But we
+     * are not handling such cases here.
+     *
+     * @var integer
+     */
+    const RELEASE_WAIT_TIMEOUT = 120;
+
+    /**
+     * Number of retries before giving up on the job.
+     *
+     * @var integer
+     */
+    const MAX_RETRY_ATTEMPTS = 10;
+
+    /**
+     * Instantiate a new Client
+     *
+     * @param string        $endpoint   endpoint
+     * @param array         $attributes attributes
+     * @param QueueContract $queue      queue
+     * @param Guzzle        $guzzle     guzzle
+     *
+     * @return void
+     */
+    public function __construct($endpoint, array $attributes = [],
+                                QueueContract $queue = null,
+                                Guzzle $guzzle = null)
     {
-        $job->delete();
-    }
-    else
-    {
-      try
-      {
-          $this->messagePoster($data);
+        $this->endpoint = $endpoint;
 
-          $job->delete();
-      }
-      catch(ClientException $e)
-      {
-          $job->release(self::RELEASE_WAIT_TIMEOUT);
-      }
-    }
-  }
+        if (isset($attributes['channel']))
+        {
+            $this->setDefaultChannel($attributes['channel']);
+        }
 
-  /**
-   * Prepares the payload to be sent to the webhook
-   *
-   * @param \Maknz\Slack\Message $message The message to send
-   * @return array
-   */
-  public function preparePayload(Message $message, $numRetries = null)
-  {
-    $payload = [
-      'text' => $message->getText(),
-      'channel' => $message->getChannel(),
-      'username' => $message->getUsername(),
-      'link_names' => $this->getLinkNames() ? 1 : 0,
-      'unfurl_links' => $this->getUnfurlLinks(),
-      'unfurl_media' => $this->getUnfurlMedia(),
-      'mrkdwn' => $message->getAllowMarkdown()
-    ];
+        if (isset($attributes['username']))
+        {
+            $this->setDefaultUsername($attributes['username']);
+        }
 
-    if($numRetries)
-    {
-      $payload['metadata'] = ['num_retries' => $numRetries];
+        if (isset($attributes['icon']))
+        {
+            $this->setDefaultIcon($attributes['icon']);
+        }
+
+        if (isset($attributes['link_names']))
+        {
+            $this->setLinkNames($attributes['link_names']);
+        }
+
+        if (isset($attributes['unfurl_links']))
+        {
+            $this->setUnfurlLinks($attributes['unfurl_links']);
+        }
+
+        if (isset($attributes['unfurl_media']))
+        {
+            $this->setUnfurlMedia($attributes['unfurl_media']);
+        }
+
+        if (isset($attributes['allow_markdown']))
+        {
+            $this->setAllowMarkdown($attributes['allow_markdown']);
+        }
+
+        if (isset($attributes['markdown_in_attachments']))
+        {
+            $this->setMarkdownInAttachments($attributes['markdown_in_attachments']);
+        }
+
+        if(isset($attributes['is_slack_enabled']))
+        {
+            $this->setSlackStatus($attributes['is_slack_enabled']);
+        }
+
+        $this->guzzle = $guzzle ?: new Guzzle;
+
+        $this->queue = $queue;
+
+        $this->maxRetryAttempts = self::MAX_RETRY_ATTEMPTS;
     }
 
-    if ($icon = $message->getIcon())
+    /**
+     * Sets the queue to be used
+     *
+     * @param string $queue Name of the queue
+     *
+    * @return $this
+    */
+    public function setQueue(QueueContract $queue)
     {
-      $payload[$message->getIconType()] = $icon;
+        $this->queue = $queue;
+
+        return $this;
     }
 
-    $payload['attachments'] = $this->getAttachmentsAsArrays($message);
-
-    return $payload;
-  }
-
-  /**
-   * Get the attachments in array form
-   *
-   * @param \Maknz\Slack\Message $message
-   * @return array
-   */
-  protected function getAttachmentsAsArrays(Message $message)
-  {
-    $attachments = [];
-
-    foreach ($message->getAttachments() as $attachment)
+    /**
+     * Get the queue to be used
+     *
+     * @return string
+     */
+    public function getQueue()
     {
-      $attachments[] = $attachment->toArray();
+        return $this->queue;
     }
 
-    return $attachments;
-  }
+    /**
+     * Pass any unhandled methods through to a new Message
+     * instance
+     *
+     * @param string $name      The name of the method
+     * @param array  $arguments The method arguments
+     *
+     * @return \Maknz\Slack\Message
+    */
+    public function __call($name, $arguments)
+    {
+        $message = $this->createMessage();
+
+        call_user_func_array([$message, $name], $arguments);
+
+        return $message;
+    }
+
+    /**
+     * Get the Slack endpoint
+     *
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Set the Slack endpoint
+     *
+     * @param string $endpoint endpoint
+     *
+     * @return void
+     */
+    public function setEndpoint($endpoint)
+    {
+        $this->endpoint = $endpoint;
+    }
+
+    /**
+     * Get the default channel messages will be created for
+     *
+     * @return string
+     */
+    public function getDefaultChannel()
+    {
+        return $this->channel;
+    }
+
+    /**
+     * Set the default channel messages will be created for
+     *
+     * @param string $channel channel
+     *
+     * @return void
+     */
+    public function setDefaultChannel($channel)
+    {
+        $this->channel = $channel;
+    }
+
+    /**
+     * Get the default username messages will be created for
+     *
+     * @return string
+     */
+    public function getDefaultUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Set the default username messages will be created for
+     *
+     * @param string $username username
+     *
+     * @return void
+     */
+    public function setDefaultUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * Get the default icon messages will be created with
+     *
+     * @return string
+     */
+    public function getDefaultIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * Set the default icon messages will be created with
+     *
+     * @param string $icon icon
+     *
+     * @return void
+     */
+    public function setDefaultIcon($icon)
+    {
+        $this->icon = $icon;
+    }
+
+    /**
+     * Get whether messages sent will have names (like @regan)
+     * will be converted into links
+     *
+     * @return boolean
+     */
+    public function getLinkNames()
+    {
+        return $this->link_names;
+    }
+
+    /**
+     * Returns the QueueManager instance being used
+     *
+     * @return Illuminate\Queue\QueueManager
+     */
+    public function getQueueManager()
+    {
+        return $this->queue;
+    }
+
+    /**
+     * Set whether messages sent will have names (like @regan)
+     * will be converted into links
+     *
+     * @param boolean $value value
+     *
+     * @return void
+     */
+    public function setLinkNames($value)
+    {
+        $this->link_names = (boolean) $value;
+    }
+
+    /**
+     * Get whether text links should be unfurled
+     *
+     * @return boolean
+     */
+    public function getUnfurlLinks()
+    {
+        return $this->unfurl_links;
+    }
+
+    /**
+     * Set whether text links should be unfurled
+     *
+     * @param boolean $value value
+     *
+     * @return void
+     */
+    public function setUnfurlLinks($value)
+    {
+        $this->unfurl_links = (boolean) $value;
+    }
+
+    /**
+     * Get whether media links should be unfurled
+     *
+     * @return boolean
+     */
+    public function getUnfurlMedia()
+    {
+        return $this->unfurl_media;
+    }
+
+    /**
+     * Set whether media links should be unfurled
+     *
+     * @param boolean $value value
+     *
+     * @return void
+     */
+    public function setUnfurlMedia($value)
+    {
+        $this->unfurl_media = (boolean) $value;
+    }
+
+    /**
+     * Get whether message text should be formatted with
+     * Slack's Markdown-like language
+     *
+     * @return boolean
+     */
+    public function getAllowMarkdown()
+    {
+        return $this->allow_markdown;
+    }
+
+    /**
+     * Set whether message text should be formatted with
+     * Slack's Markdown-like language
+     *
+     * @param boolean $value value
+     * @return void
+     */
+    public function setAllowMarkdown($value)
+    {
+        $this->allow_markdown = (boolean) $value;
+    }
+
+    /**
+     * Get the attachment fields which should be formatted
+     * in Slack's Markdown-like language
+     *
+     * @return array
+     */
+    public function getMarkdownInAttachments()
+    {
+        return $this->markdown_in_attachments;
+    }
+
+    /**
+     * Set the attachment fields which should be formatted
+     * in Slack's Markdown-like language
+     *
+     * @param array $fields fields
+     *
+     * @return void
+     */
+    public function setMarkdownInAttachments(array $fields)
+    {
+        $this->markdown_in_attachments = $fields;
+    }
+
+    /**
+     * Set whether slack mode is enabled/disabled
+     *
+     * @param boolean $status status
+     *
+     * @return void
+     */
+    public function setSlackStatus($status)
+    {
+        $this->slackStatus = $status;
+    }
+
+    /**
+     * Gets the current slack mode - enabled/disabled
+     *
+     * @return boolean
+     */
+    public function getSlackStatus()
+    {
+        return $this->slackStatus;
+    }
+
+    /**
+     * Create a new message with defaults
+     *
+     * @return \Maknz\Slack\Message
+     */
+    public function createMessage()
+    {
+        $message = new Message($this);
+
+        $message->setChannel($this->getDefaultChannel());
+
+        $message->setUsername($this->getDefaultUsername());
+
+        $message->setIcon($this->getDefaultIcon());
+
+        $message->setAllowMarkdown($this->getAllowMarkdown());
+
+        $message->setMarkdownInAttachments($this->getMarkdownInAttachments());
+
+        return $message;
+    }
+
+    /**
+     * Actually send the message
+     *
+     * @param array $data Slack Payload
+     *
+     * @return void
+     * @throws GuzzleHttp\Exception\ClientException   throws exception due to network errors. The client/caller
+     *                                                needs to handle this as the resulting behavior might be
+     *                                                different for different client calls between syncronous and
+     *                                                asynchronous calls
+     */
+    protected function messagePoster($data)
+    {
+        $encoded = json_encode($data, JSON_UNESCAPED_UNICODE);
+
+        $this->guzzle->post($this->endpoint, ['body' => $encoded]);
+    }
+
+    /**
+     * Send a message
+     *
+     * @param \Maknz\Slack\Message $message message
+     *
+     * @return void
+     */
+    public function sendMessage(Message $message)
+    {
+        $payload = $message->getPayload();
+
+        $this->messagePoster($payload);
+    }
+
+    /**
+     * Queue a message
+     *
+     * @param \Maknz\Slack\Message $message message
+     * @return void
+     */
+    public function queueMessage(Message $message, $numRetries)
+    {
+        $payload = $message->getPayload();
+
+        $this->maxRetryAttempts = $numRetries;
+
+        $this->queue->push(__CLASS__, $payload);
+    }
+
+    /**
+     * Execute the message sending via a Queue
+     *
+     * @param Illuminate\Queue\Jobs\Job $job  Job instance
+     * @param array                     $data Slack Payload
+     *
+     * @return void
+     */
+    public function fire($job, array $data)
+    {
+        if($job->attempts() >= $data['metadata']['num_retries'])
+        {
+            $job->delete();
+        }
+        else
+        {
+            try
+            {
+                $this->messagePoster($data);
+
+                $job->delete();
+            }
+            catch(ClientException $e)
+            {
+                $job->release(self::RELEASE_WAIT_TIMEOUT);
+            }
+        }
+    }
+
+    /**
+     * Prepares the payload to be sent to the webhook
+     *
+     * @param \Maknz\Slack\Message $message The message to send
+     *
+     * @return array
+     */
+    public function preparePayload(Message $message, $numRetries = null)
+    {
+        $payload = [
+          'text'         => $message->getText(),
+          'channel'      => $message->getChannel(),
+          'username'     => $message->getUsername(),
+          'link_names'   => $this->getLinkNames() ? 1 : 0,
+          'unfurl_links' => $this->getUnfurlLinks(),
+          'unfurl_media' => $this->getUnfurlMedia(),
+          'mrkdwn'       => $message->getAllowMarkdown()
+        ];
+
+        if($numRetries)
+        {
+            $payload['metadata'] = ['num_retries' => $numRetries];
+        }
+
+        if ($icon = $message->getIcon())
+        {
+            $payload[$message->getIconType()] = $icon;
+        }
+
+        $payload['attachments'] = $this->getAttachmentsAsArrays($message);
+
+        return $payload;
+    }
+
+    /**
+     * Get the attachments in array form
+     *
+     * @param \Maknz\Slack\Message $message message
+     *
+     * @return array
+     */
+    protected function getAttachmentsAsArrays(Message $message)
+    {
+
+        $attachments = [];
+
+        foreach ($message->getAttachments() as $attachment)
+        {
+            $attachments[] = $attachment->toArray();
+        }
+
+        return $attachments;
+    }
 
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -124,9 +124,11 @@ class Client
      *
      * @return void
      */
-    public function __construct($endpoint, array $attributes = [],
-                                QueueContract $queue = null,
-                                Guzzle $guzzle = null)
+    public function __construct(
+        $endpoint,
+        array $attributes = [],
+        QueueContract $queue = null,
+        Guzzle $guzzle = null)
     {
         $this->endpoint = $endpoint;
 
@@ -183,7 +185,8 @@ class Client
     }
 
     /**
-     * Sets the queue to be used
+     * Sets the Connection of Queue to be used
+     * Please Note: This Sets the Connection not the Queue
      *
      * @param string $queue Name of the queue
      *
@@ -197,7 +200,8 @@ class Client
     }
 
     /**
-     * Get the queue to be used
+     * Get the Queue Connection to be used
+     * Please Note: This Gets the Connection not the Queue
      *
      * @return string
      */
@@ -519,13 +523,13 @@ class Client
      * @param \Maknz\Slack\Message $message message
      * @return void
      */
-    public function queueMessage(Message $message, $numRetries)
+    public function queueMessage(Message $message, $numRetries, $queue = null)
     {
         $payload = $message->getPayload();
 
         $this->maxRetryAttempts = $numRetries;
 
-        $this->queue->push(__CLASS__, $payload);
+        $this->queue->push(__CLASS__, $payload, $queue);
     }
 
     /**
@@ -538,7 +542,7 @@ class Client
      */
     public function fire($job, array $data)
     {
-        if($job->attempts() >= $data['metadata']['num_retries'])
+        if ($job->attempts() >= $data['metadata']['num_retries'])
         {
             $job->delete();
         }
@@ -576,7 +580,7 @@ class Client
           'mrkdwn'       => $message->getAllowMarkdown()
         ];
 
-        if($numRetries)
+        if ($numRetries)
         {
             $payload['metadata'] = ['num_retries' => $numRetries];
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -448,11 +448,9 @@ class Client {
 
     try
     {
-        $this->messagePoster($data);
+      $this->guzzlePoster($data);
 
-        $job->delete();
-
-        $isMessageSent = true;
+      $job->delete();
     }
     catch(ClientException $e)
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -448,7 +448,7 @@ class Client {
    * @param \Maknz\Slack\Message $message
    * @return void
    */
-  public function queueMessage(Message $message, $numRetries = self::MAX_RETRY_ATTEMPTS)
+  public function queueMessage(Message $message, $numRetries)
   {
 
     $payload = $message->getPayload();

--- a/src/Client.php
+++ b/src/Client.php
@@ -505,12 +505,12 @@ class Client {
 
     if($numRetries)
     {
-        $payload['metadata'] = ['num_retries' => $numRetries];
+      $payload['metadata'] = ['num_retries' => $numRetries];
     }
 
     if ($icon = $message->getIcon())
     {
-        $payload[$message->getIconType()] = $icon;
+      $payload[$message->getIconType()] = $icon;
     }
 
     $payload['attachments'] = $this->getAttachmentsAsArrays($message);

--- a/src/Client.php
+++ b/src/Client.php
@@ -396,6 +396,7 @@ class Client {
   protected function guzzlePoster($data)
   {
     $encoded = json_encode($data, JSON_UNESCAPED_UNICODE);
+
     $this->guzzle->post($this->endpoint, ['body' => $encoded]);
   }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -475,15 +475,18 @@ class Client {
     {
         $job->delete();
     }
-    try
+    else
     {
-        $this->messagePoster($data);
+      try
+      {
+          $this->messagePoster($data);
 
-        $job->delete();
-    }
-    catch(ClientException $e)
-    {
-        $job->release(self::RELEASE_WAIT_TIMEOUT);
+          $job->delete();
+      }
+      catch(ClientException $e)
+      {
+          $job->release(self::RELEASE_WAIT_TIMEOUT);
+      }
     }
   }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -437,7 +437,7 @@ class Client {
    */
   public function sendMessage(Message $message)
   {
-    $payload = $this->preparePayload($message);
+    $payload = $message->getPayload();
 
     $this->messagePoster($payload);
   }
@@ -450,13 +450,8 @@ class Client {
    */
   public function queueMessage(Message $message, $numRetries = self::MAX_RETRY_ATTEMPTS)
   {
-    // check for malicious calls and if so, try max times
-    if ($numRetries <= 0)
-    {
-        $numRetries = self::MAX_RETRY_ATTEMPTS;
-    }
 
-    $payload = $this->preparePayload($message, $numRetries);
+    $payload = $message->getPayload();
 
     $this->maxRetryAttempts = $numRetries;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -100,7 +100,7 @@ class Client {
    *
    * @var integer
    */
-  const RELEASE_WAIT_TIMEOUT = 5;
+  const RELEASE_WAIT_TIMEOUT = 120;
 
   /**
    * Number of retries before giving up on the job.
@@ -108,8 +108,6 @@ class Client {
    * @var integer
    */
   const MAX_RETRY_ATTEMPTS = 10;
-
-  protected $orig_endpoint = null;
 
 
   /**
@@ -452,9 +450,8 @@ class Client {
    */
   public function queueMessage(Message $message, $numRetries)
   {
-    $payload = $message->getPayload();
 
-    $this->orig_endpoint = $this->getEndpoint();
+    $payload = $message->getPayload();
 
     $this->maxRetryAttempts = $numRetries;
 
@@ -469,10 +466,6 @@ class Client {
    */
   public function fire($job, array $data)
   {
-    if($this->orig_endpoint === null)
-    {
-        $this->orig_endpoint = $this->getEndpoint();
-    }
     if($job->attempts() >= $data['metadata']['num_retries'])
     {
         $job->delete();
@@ -481,22 +474,12 @@ class Client {
     {
       try
       {
-          if($job->attempts() <= 5)
-          {
-            $this->setEndpoint('http://www.google.com');
-            S("Job Attempt:".$job->attempts().", Endpoint:". $this->endpoint);
-          }
-          else
-          {
-              $this->setEndpoint($this->orig_endpoint);
-              S("Job Attempt:".$job->attempts().", Endpoint:". $this->endpoint);
-          }
           $this->messagePoster($data);
+
           $job->delete();
       }
       catch(ClientException $e)
       {
-          S("Reached exception...releasing Job:".$job->attempts().", for:".self::RELEASE_WAIT_TIMEOUT);
           $job->release(self::RELEASE_WAIT_TIMEOUT);
       }
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -87,6 +87,13 @@ class Client {
   protected $queue;
 
   /**
+   * Slack Enable mode
+   * @var boolean
+   */
+  protected $slackStatus = true;
+
+
+  /**
    * Queue wait timeout on releasing the job. Ideally, for a more complicated scenario
    * the wait timeout could increase based on the number of failures. But we
    * are not handling such cases here.
@@ -129,6 +136,8 @@ class Client {
     if (isset($attributes['allow_markdown'])) $this->setAllowMarkdown($attributes['allow_markdown']);
 
     if (isset($attributes['markdown_in_attachments'])) $this->setMarkdownInAttachments($attributes['markdown_in_attachments']);
+
+    if(isset($attributes['is_slack_enabled'])) $this->setSlackStatus($attributes['is_slack_enabled']);
 
     $this->guzzle = $guzzle ?: new Guzzle;
 
@@ -362,6 +371,27 @@ class Client {
   }
 
   /**
+   * Set whether slack mode is enabled/disabled
+   *
+   * @param boolean $status
+   * @return void
+   */
+  public function setSlackStatus($status)
+  {
+    $this->slackStatus = $status;
+  }
+
+  /**
+   * Gets the current slack mode - enabled/disabled
+   *
+   * @return boolean
+   */
+  public function getSlackStatus()
+  {
+    return $this->slackStatus;
+  }
+
+  /**
    * Create a new message with defaults
    *
    * @return \Maknz\Slack\Message
@@ -418,7 +448,7 @@ class Client {
    * @param \Maknz\Slack\Message $message
    * @return void
    */
-  public function queueMessage(Message $message, $numRetries)
+  public function queueMessage(Message $message, $numRetries = self::MAX_RETRY_ATTEMPTS)
   {
     // check for malicious calls and if so, try max times
     if ($numRetries <= 0)

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 use GuzzleHttp\Client as Guzzle;
 use Illuminate\Queue\Capsule\Manager as Queue;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
 use GuzzleHttp\Exception\ClientException;
 
 class Client {
@@ -117,7 +118,7 @@ class Client {
    * @param array $attributes
    * @return void
    */
-  public function __construct($endpoint, array $attributes = [], Queue $queue = null, Guzzle $guzzle = null)
+  public function __construct($endpoint, array $attributes = [],QueueContract $queue = null, Guzzle $guzzle = null)
   {
     $this->endpoint = $endpoint;
 
@@ -143,12 +144,30 @@ class Client {
 
     $this->queue = $queue;
 
-    if($this->queue !== null)
-      $this->queue->setAsGlobal();
-
     $this->maxRetryAttempts = self::MAX_RETRY_ATTEMPTS;
   }
 
+  /**
+   * Sets the queue to be used
+   * @param string $queue Name of the queue
+   * @return $this
+   */
+  public function setQueue(QueueManager $queue)
+  {
+    $this->queue = $queue;
+
+    return $this;
+  }
+
+  /**
+   * Get the queue to be used
+   *
+   * @return string
+   */
+  public function getQueue()
+  {
+    return $this->queue;
+  }
   /**
    * Pass any unhandled methods through to a new Message
    * instance

--- a/src/Client.php
+++ b/src/Client.php
@@ -441,16 +441,15 @@ class Client {
    */
   public function fire($job, array $data)
   {
-    if($job->attempts() >= $data['num_retries'])
+    if($job->attempts() >= $data['metadata']['num_retries'])
     {
         $job->delete();
     }
-
     try
     {
-      $this->guzzlePoster($data);
+        $this->messagePoster($data);
 
-      $job->delete();
+        $job->delete();
     }
     catch(ClientException $e)
     {
@@ -478,7 +477,7 @@ class Client {
 
     if($numRetries)
     {
-        $payload['num_retries'] = $numRetries;
+        $payload['metadata'] = ['num_retries' => $numRetries];
     }
 
     if ($icon = $message->getIcon())

--- a/src/Client.php
+++ b/src/Client.php
@@ -100,7 +100,7 @@ class Client {
    *
    * @var integer
    */
-  const RELEASE_WAIT_TIMEOUT = 10;
+  const RELEASE_WAIT_TIMEOUT = 120;
 
   /**
    * Number of retries before giving up on the job.

--- a/src/Facades/Slack.php
+++ b/src/Facades/Slack.php
@@ -1,14 +1,20 @@
-<?php namespace Maknz\Slack\Facades;
+<?php
+
+namespace Maknz\Slack\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class Slack extends Facade {
+class Slack extends Facade
+{
 
-  /**
-   * Get the registered name of the component.
-   *
-   * @return string
-   */
-  protected static function getFacadeAccessor() { return 'slack'; }
 
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'slack';
+    }
 }

--- a/src/Facades/Slack.php
+++ b/src/Facades/Slack.php
@@ -9,6 +9,6 @@ class Slack extends Facade {
    *
    * @return string
    */
-  protected static function getFacadeAccessor() { return 'maknz.slack'; }
+  protected static function getFacadeAccessor() { return 'slack'; }
 
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -410,8 +410,7 @@ class Message {
   }
 
   /**
-   * Send the message
-   * We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
+   * Notes: We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
    * we will push the message into the queue. Another implementation could be
    * a blocking implementation where the number of retries and the wait timeout could
    * be specified through the method call. We are not going ahead with that at this
@@ -428,8 +427,11 @@ class Message {
 
     $numAttempts = 0;
 
-    // check for malicious calls and if so, try once atleast
-    if ($numRetries <= 0) $numRetries = 1;
+    // check for malicious calls and if so, try once at least
+    if ($numRetries <= 0)
+    {
+      $numRetries = 1;
+    }
 
     while(($numAttempts < $numRetries) and
           ($isMessageSent === false))
@@ -449,7 +451,6 @@ class Message {
     {
       $this->queue($text, $numRetries);
     }
-
   }
 
   /**
@@ -470,10 +471,10 @@ class Message {
 
   /**
    * @param string $headline
-   * @param array  $postdata
-   * @param string pretext
+   * @param array  $postData
+   * @param string $pretext
    */
-   protected function buildMessage($headline, array $postdata, $pretext)
+   protected function buildMessage($headline, array $postData, $pretext)
    {
       //  Fallback text for plaintext clients, like IRC
       $data = [];
@@ -485,10 +486,10 @@ class Message {
       $data['pretext']    = $pretext;
 
       // If our data is nested, we need to flatten it
-      $postdata = flatten_array($postdata);
+      $postData = flatten_array($postData);
 
       // attach for all extra fields
-      foreach($postdata as $key => $value)
+      foreach($postData as $key => $value)
       {
           //  Fallback text for plaintext clients, like IRC
           $data['fallback'] .= $key . ': ' . $value . '\n';
@@ -507,21 +508,20 @@ class Message {
 
   /**
    * @param string $headline
-   * @param array $postdata actual post data
+   * @param array $postData actual post data
    * @param array $settings post meta data - username, icon etc
    * @param string $pretext
    * @param bool $asQueue
    * @param integer $numRetries
    */
-  public function messageHandler($headline, array $postdata, array $settings = [],
+  public function messageHandler($headline, array $postData, array $settings = [],
                                  $pretext = '', $asQueue = true, $numRetries = self::MAX_RETRY_ATTEMPTS)
   {
-      $data = $this->buildMessage($headline, $postdata, $pretext);
+      $data = $this->buildMessage($headline, $postData, $pretext);
 
       $settings['username'] = isset($settings['username']) ? $settings['username'] : null;
 
       $settings['icon']     = isset($settings['icon']) ? $settings['icon'] : null;
-
 
       if (isset($settings['channel']))
       {

--- a/src/Message.php
+++ b/src/Message.php
@@ -468,18 +468,14 @@ class Message {
 
   /**
    * @param string $headline
-   * @param array $data message metadata
-   * @param array $postdata actual post data
-   * @param array $settings post meta data - username, icon etc
-   * @param string $pretext
-   * @param bool $asQueue
-   * @param integer $numRetries
+   * @param array  $postdata
+   * @param string pretext
    */
-  public function messageHandler($headline, array $data, array $postdata, array $settings = [],
-                                 $pretext = '', $asQueue = true, $numRetries = self::MAX_RETRY_ATTEMPTS)
-  {
-
+   protected function buildMessage($headline, array $postdata, $pretext)
+   {
       //  Fallback text for plaintext clients, like IRC
+      $data = [];
+
       $data['fallback']   = $headline.'\n';
 
       $data['fields']     = [];
@@ -488,10 +484,6 @@ class Message {
 
       // If our data is nested, we need to flatten it
       $postdata = flatten_array($postdata);
-
-      $settings['username'] = isset($settings['username']) ? $settings['username'] : null;
-
-      $settings['icon']     = isset($settings['icon']) ? $settings['icon'] : null;
 
       // attach for all extra fields
       foreach($postdata as $key => $value)
@@ -507,6 +499,27 @@ class Message {
               'short' => true,
           );
       }
+
+      return $data;
+   }
+
+  /**
+   * @param string $headline
+   * @param array $postdata actual post data
+   * @param array $settings post meta data - username, icon etc
+   * @param string $pretext
+   * @param bool $asQueue
+   * @param integer $numRetries
+   */
+  public function messageHandler($headline, array $postdata, array $settings = [],
+                                 $pretext = '', $asQueue = true, $numRetries = self::MAX_RETRY_ATTEMPTS)
+  {
+      $data = $this->buildMessage($headline, $postdata, $pretext);
+
+      $settings['username'] = isset($settings['username']) ? $settings['username'] : null;
+
+      $settings['icon']     = isset($settings['icon']) ? $settings['icon'] : null;
+
 
       if (isset($settings['channel']))
       {

--- a/src/Message.php
+++ b/src/Message.php
@@ -621,29 +621,6 @@ class Message {
 
   }
 
-
-  /**
-   * Sets the queue to be used
-   * @param string $queue Name of the queue
-   * @return $this
-   */
-  public function setQueue($queue)
-  {
-    $this->queue = $queue;
-
-    return $this;
-  }
-
-  /**
-   * Get the queue to be used
-   *
-   * @return string
-   */
-  public function getQueue()
-  {
-    return $this->queue;
-  }
-
   /** Flatten multi dimensional array into a single dimensional array
    * @param array $array
    * @param string $separator

--- a/src/Message.php
+++ b/src/Message.php
@@ -145,6 +145,16 @@ class Message {
     return $this->payload;
   }
 
+  /**
+   * Set the payload
+   * @return array
+   */
+  public function setPayload(array $payload)
+  {
+    $this->payload = $payload;
+
+  }
+
 
   /**
    * Get the channel we will post to
@@ -463,6 +473,7 @@ class Message {
     // push it into the queue
     if(!$isMessageSent)
     {
+      $this->setPayload($this->client->preparePayload($this, $numRetries));
       $this->_queue($text, $numRetries);
     }
   }
@@ -556,14 +567,15 @@ class Message {
         $this->setText($headline);
       }
 
-      $this->client->preparePayload($this);
 
       if($asQueue)
       {
+          $this->setPayload($this->client->preparePayload($this, $numRetries));
           $this->_queue($headline, $numRetries);
       }
       else
       {
+          $this->setPayload($this->client->preparePayload($this));
           $this->_send($headline, $numRetries);
       }
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -419,7 +419,7 @@ class Message {
    * @param string $text The text to send
    * @return void
    */
-  public function send($text = null, $numRetries = self::MAX_RETRY_ATTEMPTS)
+  protected function _send($text = null, $numRetries = self::MAX_RETRY_ATTEMPTS)
   {
     if($text)
     {
@@ -463,7 +463,7 @@ class Message {
    * @param  integer $numRetries The number of times to retry on failure
    * @return void
    */
-  public function queue($text = null, $numRetries)
+  protected function _queue($text = null, $numRetries)
   {
     if ($text)
     {
@@ -519,7 +519,7 @@ class Message {
    * @param bool $asQueue
    * @param integer $numRetries
    */
-  public function messageHandler($headline, array $postData, array $settings = [],
+  protected function messageHandler($headline, array $postData, array $settings = [],
                                  $pretext = '', $asQueue = true, $numRetries = self::MAX_RETRY_ATTEMPTS)
   {
       $data = $this->buildMessage($headline, $postData, $pretext);
@@ -542,14 +542,55 @@ class Message {
 
       if($asQueue)
       {
-          $this->queue($headline, $numRetries);
+          $this->_queue($headline, $numRetries);
       }
       else
       {
-          $this->send($headline, $numRetries);
+          $this->_send($headline, $numRetries);
       }
 
   }
+
+  /**
+   * Queue the message for delivery later
+   * @param string $headline
+   * @param array $postData actual post data
+   * @param array $settings post meta data - username, icon etc
+   * @param string $pretext
+   * @param integer $numRetries
+   * @return void
+   */
+  public function queue($headline, array $postData, array $settings = [],
+                        $pretext = '',$numRetries = self::MAX_RETRY_ATTEMPTS)
+  {
+    if($this->client->getSlackStatus())
+    {
+      return $this->messageHandler($headline, $postData, $settings, $pretext, true, $numRetries);
+    }
+
+  }
+
+  /**
+   * Send the message immediately
+   * @param string $headline
+   * @param array $postData actual post data
+   * @param array $settings post meta data - username, icon etc
+   * @param string $pretext
+   * @param integer $numRetries
+   * @return void
+   */
+
+  public function send($headline, array $postData, array $settings = [],
+                       $pretext = '',$numRetries = self::MAX_RETRY_ATTEMPTS)
+  {
+    if($this->client->getSlackStatus())
+    {
+      return $this->messageHandler($headline, $postData, $settings, $pretext, false, $numRetries);
+
+    }
+
+  }
+
 
   /**
    * Sets the queue to be used

--- a/src/Message.php
+++ b/src/Message.php
@@ -356,7 +356,7 @@ class Message {
     {
       $attachmentObject = new Attachment($attachment);
 
-      if ( ! isset($attachment['mrkdwn_in']))
+      if (! isset($attachment['mrkdwn_in']))
       {
         $attachmentObject->setMarkdownFields($this->getMarkdownInAttachments());
       }
@@ -411,15 +411,14 @@ class Message {
 
   /**
    * Send the message
-   *
-   * @param string $text The text to send
-   * @return void
-   * Notes: We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
+   * We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
    * we will push the message into the queue. Another implementation could be
    * a blocking implementation where the number of retries and the wait timeout could
    * be specified through the method call. We are not going ahead with that at this
    * point since it might end up blocking. We are also not waiting before retry for
    * the same reason.
+   * @param string $text The text to send
+   * @return void
    */
   public function send($text = null, $numRetries = self::MAX_RETRY_ATTEMPTS)
   {
@@ -448,7 +447,7 @@ class Message {
     // push it into the queue
     if(!$isMessageSent)
     {
-      $this->queue($text);
+      $this->queue($text, $numRetries);
     }
 
   }
@@ -461,7 +460,10 @@ class Message {
    */
   public function queue($text = null, $numRetries)
   {
-    if ($text) $this->setText($text);
+    if ($text)
+    {
+        $this->setText($text);
+    }
 
     $this->client->queueMessage($this, $this->queue, $numRetries);
   }
@@ -535,11 +537,11 @@ class Message {
 
       if($asQueue)
       {
-        $this->queue($headline, $numRetries);
+          $this->queue($headline, $numRetries);
       }
       else
       {
-        $this->send($headline, $numRetries);
+          $this->send($headline, $numRetries);
       }
 
   }

--- a/src/Message.php
+++ b/src/Message.php
@@ -482,7 +482,7 @@ class Message {
    */
    protected function buildMessage($headline, array $postData, $pretext)
    {
-      //  Fallback text for plaintext clients, like IRC
+      // Fallback text for plaintext clients, like IRC
       $data = [];
 
       $data['fallback']   = $headline.'\n';
@@ -568,7 +568,6 @@ class Message {
     {
       return $this->messageHandler($headline, $postData, $settings, $pretext, true, $numRetries);
     }
-
   }
 
   /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -421,7 +421,10 @@ class Message {
    */
   public function send($text = null, $numRetries = self::MAX_RETRY_ATTEMPTS)
   {
-    if ($text) $this->setText($text);
+    if($text)
+    {
+      $this->setText($text);
+    }
 
     $isMessageSent = false;
 
@@ -443,6 +446,7 @@ class Message {
         $isMessageSent = true;
       }
       catch(Exception $e){}
+
       $numAttempts += 1;
     }
 
@@ -473,6 +477,7 @@ class Message {
    * @param string $headline
    * @param array  $postData
    * @param string $pretext
+   * @return $data
    */
    protected function buildMessage($headline, array $postData, $pretext)
    {

--- a/src/Message.php
+++ b/src/Message.php
@@ -410,7 +410,8 @@ class Message {
   }
 
   /**
-   * Notes: We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
+   * Send the message
+   * We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
    * we will push the message into the queue. Another implementation could be
    * a blocking implementation where the number of retries and the wait timeout could
    * be specified through the method call. We are not going ahead with that at this

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,648 +1,673 @@
-<?php namespace Maknz\Slack;
+<?php
+
+namespace Maknz\Slack;
 
 use InvalidArgumentException;
 
-class Message {
+class Message
+{
 
-  /**
-   * Reference to the Slack client responsible for sending
-   * the message
-   *
-   * @var \Maknz\Slack\Client
-   */
-  protected $client;
+    /**
+     * Reference to the Slack client responsible for sending
+     * the message
+     *
+     * @var \Maknz\Slack\Client
+     */
+    protected $client;
 
-  /**
-   * The text to send with the message
-   *
-   * @var string
-   */
-  protected $text;
+    /**
+     * The text to send with the message
+     *
+     * @var string
+     */
+    protected $text;
 
-  /**
-   * The actualy payload being created from the text for sending
-   *
-   * @var array
-   */
-  protected $payload;
+    /**
+     * The actualy payload being created from the text for sending
+     *
+     * @var array
+     */
+    protected $payload;
 
-  /**
-   * The channel the message should be sent to
-   *
-   * @var string
-   */
-  protected $channel;
+    /**
+     * The channel the message should be sent to
+     *
+     * @var string
+     */
+    protected $channel;
 
-  /**
-   * The username the message should be sent as
-   *
-   * @var string
-   */
-  protected $username;
+    /**
+     * The username the message should be sent as
+     *
+     * @var string
+     */
+    protected $username;
 
-  /**
-   * The URL to the icon to use
-   *
-   * @var string
-   */
-  protected $icon;
+    /**
+     * The URL to the icon to use
+     *
+     * @var string
+     */
+    protected $icon;
 
-  /**
-   * The type of icon we are using
-   *
-   * @var enum
-   */
-  protected $iconType;
+    /**
+     * The type of icon we are using
+     *
+     * @var enum
+     */
+    protected $iconType;
 
-  /**
-   * Whether the message text should be interpreted in Slack's
-   * Markdown-like language
-   *
-   * @var boolean
-   */
-  protected $allow_markdown = true;
+    /**
+     * Whether the message text should be interpreted in Slack's
+     * Markdown-like language
+     *
+     * @var boolean
+     */
+    protected $allowMarkdown = true;
 
-  /**
-   * The attachment fields which should be formatted with
-   * Slack's Markdown-like language
-   *
-   * @var array
-   */
-  protected $markdown_in_attachments = [];
+    /**
+     * The attachment fields which should be formatted with
+     * Slack's Markdown-like language
+     *
+     * @var array
+     */
+    protected $markdownInAttachments = [];
 
-  /**
-   * An array of attachments to send
-   *
-   * @var array
-   */
-  protected $attachments = [];
+    /**
+     * An array of attachments to send
+     *
+     * @var array
+     */
+    protected $attachments = [];
 
-  /**
-   * The name of the queue to be used
-   * @var string
-   */
-  protected $queue = null;
+    /**
+     * The name of the queue to be used
+     *
+     * @var string
+     */
+    protected $queue = null;
 
-  /**
-   *
-   * @var string
-   */
-  const ICON_TYPE_URL = 'icon_url';
+    /**
+     *
+     * @var string
+     */
+    const ICON_TYPE_URL = 'icon_url';
 
-  /**
-   *
-   * @var string
-   */
-  const ICON_TYPE_EMOJI = 'icon_emoji';
+    /**
+     *
+     * @var string
+     */
+    const ICON_TYPE_EMOJI = 'icon_emoji';
 
-  /**
-   *
-   * @var integer
-   */
-  const MAX_RETRY_ATTEMPTS = 10;
+    /**
+     *
+     * @var integer
+     */
+    const MAX_RETRY_ATTEMPTS = 10;
 
-  /**
-   * Instantiate a new Message
-   *
-   * @param \Maknz\Slack\Client $client
-   * @return void
-   */
-  public function __construct(Client $client)
-  {
-    $this->client = $client;
-  }
-
-  /**
-   * Get the message text
-   *
-   * @return string
-   */
-  public function getText()
-  {
-    return $this->text;
-  }
-
-  /**
-   * Set the message text
-   *
-   * @param string $text
-   * @return $this
-   */
-  public function setText($text)
-  {
-    $this->text = $text;
-
-    return $this;
-  }
-
-  /**
-   *  Get the payload
-   *
-   * @return array
-   */
-  public function getPayload()
-  {
-    return $this->payload;
-  }
-
-  /**
-   * Set the payload
-   * @return array
-   */
-  public function setPayload(array $payload)
-  {
-    $this->payload = $payload;
-
-  }
-
-
-  /**
-   * Get the channel we will post to
-   *
-   * @return string
-   */
-  public function getChannel()
-  {
-    return $this->channel;
-  }
-
-  /**
-   * Set the channel we will post to
-   *
-   * @param string $channel
-   * @return $this
-   */
-  public function setChannel($channel)
-  {
-    $this->channel = $channel;
-
-    return $this;
-  }
-
-  /**
-   * Get the username we will post as
-   *
-   * @return string
-   */
-  public function getUsername()
-  {
-    return $this->username;
-  }
-
-  /**
-   * Set the username we will post as
-   *
-   * @param string $username
-   * @return $this
-   */
-  public function setUsername($username)
-  {
-    $this->username = $username;
-
-    return $this;
-  }
-
-  /**
-   * Get the icon (either URL or emoji) we will post as
-   *
-   * @return string
-   */
-  public function getIcon()
-  {
-    return $this->icon;
-  }
-
-  /**
-   * Set the icon (either URL or emoji) we will post as.
-   *
-   * @param string $icon
-   * @return this
-   */
-  public function setIcon($icon)
-  {
-    if ($icon == null)
+    /**
+     * Instantiate a new Message
+     *
+     * @param \Maknz\Slack\Client $client client
+     *
+     * @return void
+     */
+    public function __construct(Client $client)
     {
-      $this->icon = $this->iconType = null;
-
-      return;
+        $this->client = $client;
     }
 
-    if (mb_substr($icon, 0, 1) == ":" && mb_substr($icon, mb_strlen($icon) - 1, 1) == ":")
+    /**
+     * Get the message text
+     *
+     * @return string
+     */
+    public function getText()
     {
-      $this->iconType = self::ICON_TYPE_EMOJI;
+        return $this->text;
     }
 
-    else
+    /**
+     * Set the message text
+     *
+     * @param string $text text
+     *
+     * @return $this
+     */
+    public function setText($text)
     {
-      $this->iconType = self::ICON_TYPE_URL;
+        $this->text = $text;
+
+        return $this;
     }
 
-    $this->icon = $icon;
-
-    return $this;
-  }
-
-  /**
-   * Get the icon type being used, if an icon is set
-   *
-   * @return string
-   */
-  public function getIconType()
-  {
-    return $this->iconType;
-  }
-
-  /**
-   * Get whether message text should be formatted with
-   * Slack's Markdown-like language
-   *
-   * @return boolean
-   */
-  public function getAllowMarkdown()
-  {
-    return $this->allow_markdown;
-  }
-
-  /**
-   * Set whether message text should be formatted with
-   * Slack's Markdown-like language
-   *
-   * @param boolean $value
-   * @return void
-   */
-  public function setAllowMarkdown($value)
-  {
-    $this->allow_markdown = (boolean) $value;
-
-    return $this;
-  }
-
-  /**
-   * Enable Markdown formatting for the message
-   *
-   * @return void
-   */
-  public function enableMarkdown()
-  {
-    $this->setAllowMarkdown(true);
-
-    return $this;
-  }
-
-  /**
-   * Disable Markdown formatting for the message
-   *
-   * @return void
-   */
-  public function disableMarkdown()
-  {
-    $this->setAllowMarkdown(false);
-
-    return $this;
-  }
-
-  /**
-   * Get the attachment fields which should be formatted
-   * in Slack's Markdown-like language
-   *
-   * @return array
-   */
-  public function getMarkdownInAttachments()
-  {
-    return $this->markdown_in_attachments;
-  }
-
-  /**
-   * Set the attachment fields which should be formatted
-   * in Slack's Markdown-like language
-   *
-   * @param array $fields
-   * @return void
-   */
-  public function setMarkdownInAttachments(array $fields)
-  {
-    $this->markdown_in_attachments = $fields;
-
-    return $this;
-  }
-
-  /**
-   * Change the name of the user the post will be made as
-   *
-   * @param string $username
-   * @return $this
-   */
-  public function from($username)
-  {
-    $this->setUsername($username);
-
-    return $this;
-  }
-
-  /**
-   * Change the channel the post will be made to
-   *
-   * @param string $channel
-   * @return $this
-   */
-  public function to($channel)
-  {
-    $this->setChannel($channel);
-
-    return $this;
-  }
-
-  /**
-   * Chainable method for setting the icon
-   *
-   * @param string $icon
-   * @return $this
-   */
-  public function withIcon($icon)
-  {
-    $this->setIcon($icon);
-
-    return $this;
-  }
-
-  /**
-   * Add an attachment to the message
-   *
-   * @param mixed $attachment
-   * @return $this
-   */
-  public function attach($attachment)
-  {
-    if ($attachment instanceof Attachment)
+    /**
+     *  Get the payload
+     *
+     * @return array
+     */
+    public function getPayload()
     {
-      $this->attachments[] = $attachment;
-
-      return $this;
+        return $this->payload;
     }
 
-    elseif (is_array($attachment))
+    /**
+     * Set the payload
+     *
+     * @param array $payload payload
+     *
+     * @return array
+     */
+    public function setPayload(array $payload)
     {
-      $attachmentObject = new Attachment($attachment);
-
-      if (! isset($attachment['mrkdwn_in']))
-      {
-        $attachmentObject->setMarkdownFields($this->getMarkdownInAttachments());
-      }
-
-      $this->attachments[] = $attachmentObject;
-
-      return $this;
+        $this->payload = $payload;
     }
 
-    throw new InvalidArgumentException('Attachment must be an instance of Maknz\\Slack\\Attachment or a keyed array');
-  }
-
-  /**
-   * Get the attachments for the message
-   *
-   * @return array
-   */
-  public function getAttachments()
-  {
-    return $this->attachments;
-  }
-
-  /**
-   * Set the attachments for the message
-   *
-   * @param string $attachments
-   * @return $this
-   */
-  public function setAttachments(array $attachments)
-  {
-    $this->clearAttachments();
-
-    foreach ($attachments as $attachment)
+    /**
+     * Get the channel we will post to
+     *
+     * @return string
+     */
+    public function getChannel()
     {
-      $this->attach($attachment);
+        return $this->channel;
     }
 
-    return $this;
-  }
-
-  /**
-   * Remove all attachments for the message
-   *
-   * @return $this
-   */
-  public function clearAttachments()
-  {
-    $this->attachments = [];
-
-    return $this;
-  }
-
-  /**
-   * Send the message
-   * We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
-   * we will push the message into the queue. Another implementation could be
-   * a blocking implementation where the number of retries and the wait timeout could
-   * be specified through the method call. We are not going ahead with that at this
-   * point since it might end up blocking. We are also not waiting before retry for
-   * the same reason.
-   * @param string $text The text to send
-   * @param integer $numRetries The number of times to attempt retrying sending the message
-   * @return void
-   */
-  protected function _send($text = null, $numRetries)
-  {
-
-    $isMessageSent = false;
-
-    $numAttempts = 0;
-
-    while(($numAttempts < $numRetries) and
-          ($isMessageSent === false))
+    /**
+     * Set the channel we will post to
+     *
+     * @param string $channel channel
+     *
+     * @return $this
+     */
+    public function setChannel($channel)
     {
-      try
-      {
-        $this->client->sendMessage($this);
+        $this->channel = $channel;
 
-        $isMessageSent = true;
-      }
-      catch(\Exception $e){}
-
-      $numAttempts += 1;
+        return $this;
     }
 
-    // push it into the queue
-    if(!$isMessageSent)
+    /**
+     * Get the username we will post as
+     *
+     * @return string
+     */
+    public function getUsername()
     {
-      $this->setPayload($this->client->preparePayload($this, $numRetries));
-
-      $this->_queue($text, $numRetries);
-    }
-  }
-
-  /**
-   * Queue the message
-   * @param  string $text The text to send
-   * @param  integer $numRetries The number of times to retry on failure
-   * @return void
-   */
-  protected function _queue($text = null, $numRetries)
-  {
-    $this->client->queueMessage($this, $this->queue, $numRetries);
-  }
-
-  /**
-   * @param string $headline
-   * @param array  $postData
-   * @param string $pretext
-   * @return $data
-   */
-   protected function buildMessage($headline, array $postData, $pretext)
-   {
-    // Fallback text for plaintext clients, like IRC
-    $data = [];
-
-    $data['fallback']   = $headline.'\n';
-
-    $data['fields']     = [];
-
-    $data['pretext']    = $pretext;
-
-    // If our data is nested, we need to flatten it
-    $postData = $this->flatten_array($postData);
-
-    // attach for all extra fields
-    foreach($postData as $key => $value)
-    {
-      //  Fallback text for plaintext clients, like IRC
-      $data['fallback'] .= $key . ': ' . $value . '\n';
-
-      $data['color'] = isset($settings['color']) ? $settings['color'] : 'good';
-
-      $data['fields'][] = array(
-              'title' => $key,
-              'value' => $value,
-              'short' => true,
-      );
+        return $this->username;
     }
 
-    return $data;
-   }
-
-  /**
-   * @param string $headline headline/title of the message as appearing on the channel.
-   * @param array $postData actual post data
-   * @param array $settings post meta data - username, icon etc
-   * @param string $pretext
-   * @param bool $asQueue boolean to determine whether the message is to be queued or sent immediately
-   * @param integer $numRetries the maximum number of times to retry sending the message.
-   */
-  protected function messageHandler($headline, array $postData, array $settings = [],
-                                 $pretext = '', $asQueue = true, $numRetries)
-  {
-    $data = $this->buildMessage($headline, $postData, $pretext);
-
-    $settings['username'] = isset($settings['username']) ? $settings['username'] : null;
-
-    $settings['icon']     = isset($settings['icon']) ? $settings['icon'] : null;
-
-    if (isset($settings['channel']))
+    /**
+     * Set the username we will post as
+     *
+     * @param string $username username
+     *
+     * @return $this
+     */
+    public function setUsername($username)
     {
-      $this->to($settings['channel'])
-                  ->from($settings['username'])
-                  ->withIcon($settings['icon'])
-                  ->attach($data);
-    }
-    else
-    {
-      $this->attach($data);
+        $this->username = $username;
+
+        return $this;
     }
 
-    // check for malicious calls.
-    if($numRetries <=0)
+    /**
+     * Get the icon (either URL or emoji) we will post as
+     *
+     * @return string
+     */
+    public function getIcon()
     {
-      $numRetries = self::MAX_RETRY_ATTEMPTS;
+        return $this->icon;
     }
 
-    if($headline)
+    /**
+     * Set the icon (either URL or emoji) we will post as.
+     *
+     * @param string $icon icon
+     *
+     * @return $this
+     */
+    public function setIcon($icon)
     {
-      $this->setText($headline);
+        $this->icon = $icon;
+
+        if ($icon === null)
+        {
+            $this->iconType = null;
+        }
+        else if (($icon[0] === ":") and ($icon[strlen($icon) - 1] === ":"))
+        {
+            $this->iconType = self::ICON_TYPE_EMOJI;
+        }
+        else
+        {
+            $this->iconType = self::ICON_TYPE_URL;
+        }
+
+        return $this;
     }
 
-    if($asQueue)
+    /**
+     * Get the icon type being used, if an icon is set
+     *
+     * @return string
+     */
+    public function getIconType()
     {
-      $this->setPayload($this->client->preparePayload($this, $numRetries));
-
-      $this->_queue($headline, $numRetries);
-    }
-    else
-    {
-      $this->setPayload($this->client->preparePayload($this));
-
-      $this->_send($headline, $numRetries);
-    }
-  }
-
-  /**
-   * Queue the message for delivery later
-   * @param string $headline headline/title of the message as appearing on the channel.
-   * @param array $postData actual post data
-   * @param array $settings post meta data - username, icon etc
-   * @param string $pretext
-   * @param integer $numRetries the maximum number of times to retry sending the message.
-   * @return void
-   */
-  public function queue($headline, array $postData, array $settings = [],
-                        $pretext = '',$numRetries = self::MAX_RETRY_ATTEMPTS)
-  {
-    if($this->client->getSlackStatus())
-    {
-      return $this->messageHandler($headline, $postData, $settings, $pretext, true, $numRetries);
-    }
-  }
-
-  /**
-   * Send the message immediately
-   * @param string $headline headline/title of the message as appearing on the channel.
-   * @param array $postData actual post data
-   * @param array $settings post meta data - username, icon etc
-   * @param string $pretext
-   * @param integer $numRetries the maximum number of times to retry sending the message.
-   * @return void
-   */
-
-  public function send($headline, array $postData, array $settings = [],
-                       $pretext = '',$numRetries = self::MAX_RETRY_ATTEMPTS)
-  {
-    if($this->client->getSlackStatus())
-    {
-      return $this->messageHandler($headline, $postData, $settings, $pretext, false, $numRetries);
-
+        return $this->iconType;
     }
 
-  }
-
-  /** Flatten multi dimensional array into a single dimensional array
-   * @param array $array
-   * @param string $separator
-   * @param string $prefix
-   * @return array
-   */
-  protected function flatten_array($array, $separator = '.', $prefix = '')
-  {
-    $result = array();
-
-    foreach ($array as $key => $value)
+    /**
+     * Get whether message text should be formatted with
+     * Slack's Markdown-like language
+     *
+     * @return boolean
+     */
+    public function getAllowMarkdown()
     {
-      $newKey = $prefix . (empty($prefix) ? '' : $separator) . $key;
-      if (is_array($value))
-      {
-        $result = array_merge($result, flatten_array($value, $separator, $newKey));
-      }
-      else
-      {
-        $result[$newKey] = $value;
-      }
+        return $this->allowMarkdown;
     }
-    return $result;
-  }
+
+    /**
+     * Set whether message text should be formatted with
+     * Slack's Markdown-like language
+     *
+     * @param boolean $value value
+     *
+     * @return $this
+     */
+    public function setAllowMarkdown($value)
+    {
+        $this->allowMarkdown = (boolean) $value;
+
+        return $this;
+    }
+
+    /**
+     * Enable Markdown formatting for the message
+     *
+     * @return $this
+     */
+    public function enableMarkdown()
+    {
+        return $this->setAllowMarkdown(true);
+    }
+
+    /**
+     * Disable Markdown formatting for the message
+     *
+     * @return $this
+     */
+    public function disableMarkdown()
+    {
+        return $this->setAllowMarkdown(false);
+    }
+
+    /**
+     * Get the attachment fields which should be formatted
+     * in Slack's Markdown-like language
+     *
+     * @return array
+     */
+    public function getMarkdownInAttachments()
+    {
+        return $this->markdownInAttachments;
+    }
+
+    /**
+     * Set the attachment fields which should be formatted
+     * in Slack's Markdown-like language
+     *
+     * @param array $fields fields
+     *
+     * @return $this
+     */
+    public function setMarkdownInAttachments(array $fields)
+    {
+        $this->markdownInAttachments = $fields;
+
+        return $this;
+    }
+
+    /**
+     * Change the name of the user the post will be made as
+     *
+     * @param string $username username
+     *
+     * @return $this
+     */
+    public function from($username)
+    {
+        $this->setUsername($username);
+
+        return $this;
+    }
+
+    /**
+     * Change the channel the post will be made to
+     *
+     * @param string $channel channel
+     *
+     * @return $this
+     */
+    public function to($channel)
+    {
+        $this->setChannel($channel);
+
+        return $this;
+    }
+
+    /**
+     * Chainable method for setting the icon
+     *
+     * @param string $icon icon
+     *
+     * @return $this
+     */
+    public function withIcon($icon)
+    {
+        $this->setIcon($icon);
+
+        return $this;
+    }
+
+    /**
+     * Add an attachment to the message
+     *
+     * @param mixed $attachment attachment
+     *
+    * @return $this
+     * @throws InvalidArgumentException
+     */
+    public function attach($attachment)
+    {
+        if ($attachment instanceof Attachment)
+        {
+            $this->attachments[] = $attachment;
+        }
+        else if (is_array($attachment) === true)
+        {
+            $attachmentObject = new Attachment($attachment);
+
+            if (isset($attachment['mrkdwn_in']) === false)
+            {
+                $attachmentObject->setMarkdownFields(
+                    $this->getMarkdownInAttachments());
+            }
+
+            $this->attachments[] = $attachmentObject;
+        }
+        else
+        {
+            throw new InvalidArgumentException(
+                'Attachment must be an instance of Slack\\Attachment or a keyed array');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the attachments for the message
+     *
+     * @return array
+     */
+    public function getAttachments()
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * Set the attachments for the message
+     *
+     * @param string $attachments attachments
+    *
+     * @return $this
+     */
+    public function setAttachments(array $attachments)
+    {
+        $this->clearAttachments();
+
+        foreach ($attachments as $attachment)
+        {
+            $this->attach($attachment);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove all attachments for the message
+     *
+     * @return $this
+     */
+    public function clearAttachments()
+    {
+        $this->attachments = [];
+
+        return $this;
+    }
+
+    /**
+     * Send the message
+     * We try to attempt to send the message MAX_RETRY_ATTEMPTS times. If it fails,
+     * we will push the message into the queue. Another implementation could be
+     * a blocking implementation where the number of retries and the wait timeout could
+     * be specified through the method call. We are not going ahead with that at this
+     * point since it might end up blocking. We are also not waiting before retry for
+     * the same reason.
+     *
+     * @param string  $text       The text to send
+     * @param integer $numRetries Number of retry attempts for sending the message
+     *
+     * @return void
+     */
+    protected function _send($text = null, $numRetries)
+    {
+        $isMessageSent = false;
+
+        $numAttempts = 0;
+
+        while(($numAttempts <= $numRetries) and ($isMessageSent === false))
+        {
+            try
+            {
+                $this->client->sendMessage($this);
+
+                $isMessageSent = true;
+            }
+            catch(\Exception $e)
+            {
+            }
+
+            $numAttempts += 1;
+        }
+
+        // push it into the queue
+        if($isMessageSent === false)
+        {
+            $this->setPayload($this->client->preparePayload($this, $numRetries));
+
+            $this->_queue($text, $numRetries);
+        }
+    }
+
+    /**
+     * Queue the message
+     *
+     * @param string  $text       The text to send
+     * @param integer $numRetries The number of times to retry on failure
+     *
+     * @return void
+     */
+    protected function _queue($text = null, $numRetries)
+    {
+        $this->client->queueMessage($this, $this->queue, $numRetries);
+    }
+
+    /**
+    * @param string $headline headline
+    * @param array  $postData postData
+    * @param string $pretext  pretext
+    *
+    * @return $data
+    */
+    protected function buildMessage($headline, array $postData, $pretext)
+    {
+        // Fallback text for plaintext clients, like IRC
+        $data = [
+            'fallback' => $headline.'\n',
+            'fields'   => [],
+            'pretext' => $pretext,
+        ];
+
+        // If our data is nested, we need to flatten it
+        $postData = $this->flatten_array($postData);
+
+        // attach for all extra fields
+        foreach($postData as $key => $value)
+        {
+            //  Fallback text for plaintext clients, like IRC
+            $data['fallback'] .= $key . ': ' . $value . '\n';
+
+            // TODO : fix this $settings is undefined
+            $data['color'] = isset($settings['color']) ? $settings['color'] : 'good';
+
+            $data['fields'][] = [
+                'title' => $key,
+                'value' => $value,
+                'short' => true,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+    * @param string $headline headline/title of the message as appearing on the channel.
+    * @param array $postData actual post data
+    * @param array $settings post meta data - username, icon etc
+    * @param string $pretext
+    * @param bool $asQueue boolean to determine whether the message is to be queued or sent immediately
+    * @param integer $numRetries the maximum number of times to retry sending the message.
+    */
+    protected function messageHandler($headline, array $postData, array $settings = [],
+                                      $pretext = '', $asQueue = true, $numRetries)
+    {
+        $data = $this->buildMessage($headline, $postData, $pretext);
+
+        $settings['username'] = isset($settings['username']) ? $settings['username'] : null;
+
+        $settings['icon']     = isset($settings['icon']) ? $settings['icon'] : null;
+
+        if (isset($settings['channel']))
+        {
+            $this->to($settings['channel'])
+                ->from($settings['username'])
+                ->withIcon($settings['icon'])
+                ->attach($data);
+        }
+        else
+        {
+            $this->attach($data);
+        }
+
+        // check for malicious calls.
+        if($numRetries <=0)
+        {
+            $numRetries = self::MAX_RETRY_ATTEMPTS;
+        }
+
+        if($headline)
+        {
+            $this->setText($headline);
+        }
+
+        if($asQueue)
+        {
+            $this->setPayload($this->client->preparePayload($this, $numRetries));
+
+            $this->_queue($headline, $numRetries);
+        }
+        else
+        {
+            $this->setPayload($this->client->preparePayload($this));
+
+            $this->_send($headline, $numRetries);
+        }
+    }
+
+    /**
+     * Queue the message for delivery later
+     *
+     * @param string  $headline   headline of the message as appearing on channel
+     * @param array   $postData   actual post data
+     * @param array   $settings   post meta data - username, icon etc
+     * @param string  $pretext    pretext
+     * @param integer $numRetries the maximum no of times to retry sending msg
+     *
+     * @return void
+     */
+    public function queue($headline, array $postData, array $settings = [],
+                          $pretext = '',$numRetries = self::MAX_RETRY_ATTEMPTS)
+    {
+        if($this->client->getSlackStatus())
+        {
+            return $this->messageHandler($headline, $postData, $settings,
+                                         $pretext, true, $numRetries);
+        }
+    }
+
+    /**
+     * Send the message immediately
+     *
+     * @param string  $headline   headline/title of the message as appearing on the channel.
+     * @param array   $postData   actual post data
+     * @param array   $settings   post meta data - username, icon etc
+     * @param string  $pretext    pretext
+     * @param integer $numRetries the maximum number of times to retry sending the message.
+     *
+     * @return void
+     */
+    public function send($headline, array $postData, array $settings = [],
+                         $pretext = '', $numRetries = self::MAX_RETRY_ATTEMPTS)
+    {
+        if($this->client->getSlackStatus())
+        {
+            return $this->messageHandler($headline, $postData, $settings,
+                                         $pretext, false, $numRetries);
+        }
+    }
+
+    /**
+     * Flatten multi dimensional array into a single dimensional array
+     *
+     * @param array  $array     array
+     * @param string $separator separator
+     * @param string $prefix    prefix
+     *
+     * @return array
+    */
+    protected function flatten_array($array, $separator = '.', $prefix = '')
+    {
+        $result = [];
+
+        foreach ($array as $key => $value)
+        {
+            $newKey = $prefix . (empty($prefix) ? '' : $separator) . $key;
+
+            if (is_array($value))
+            {
+                $result = array_merge($result, flatten_array($value,
+                                                             $separator,
+                                                             $newKey));
+            }
+            else
+            {
+                $result[$newKey] = $value;
+            }
+        }
+
+        return $result;
+    }
 }

--- a/src/SlackServiceProvider.php
+++ b/src/SlackServiceProvider.php
@@ -84,7 +84,7 @@ class SlackServiceProvider extends ServiceProvider {
   */
   public function provides()
   {
-    return ['maknz.slack'];
+    return ['slack'];
   }
 
 }

--- a/src/SlackServiceProviderLaravel4.php
+++ b/src/SlackServiceProviderLaravel4.php
@@ -49,7 +49,7 @@ class SlackServiceProviderLaravel4 extends ServiceProvider {
 
       $unfurl_media = $app['config']->get('slack::unfurl_media');
 
-      $is_slack_enabled = $app['config']->get('slack::is_slack_enabled');
+      $isSlackEnabled = $app['config']->get('slack::is_slack_enabled');
 
       return new Client(
         $app['config']->get('slack::endpoint'),
@@ -62,7 +62,7 @@ class SlackServiceProviderLaravel4 extends ServiceProvider {
           'unfurl_media' => is_bool($unfurl_media) ? $unfurl_media : true,
           'allow_markdown' => is_bool($allow_markdown) ? $allow_markdown : true,
           'markdown_in_attachments' => is_array($markdown_in_attachments) ? $markdown_in_attachments : [],
-          'is_slack_enabled' => is_bool($is_slack_enabled) ? $is_slack_enabled : true,
+          'is_slack_enabled' => is_bool($isSlackEnabled) ? $isSlackEnabled : true,
         ],
         $this->getQueue(),
         new Guzzle

--- a/src/SlackServiceProviderLaravel4.php
+++ b/src/SlackServiceProviderLaravel4.php
@@ -41,13 +41,15 @@ class SlackServiceProviderLaravel4 extends ServiceProvider {
    */
   public function register()
   {
-    $this->app['maknz.slack'] = $this->app->share(function($app)
+    $this->app['slack'] = $this->app->share(function($app)
     {
       $allow_markdown = $app['config']->get('slack::allow_markdown');
 
       $markdown_in_attachments = $app['config']->get('slack::markdown_in_attachments');
 
       $unfurl_media = $app['config']->get('slack::unfurl_media');
+
+      $is_slack_enabled = $app['config']->get('slack::is_slack_enabled');
 
       return new Client(
         $app['config']->get('slack::endpoint'),
@@ -59,14 +61,15 @@ class SlackServiceProviderLaravel4 extends ServiceProvider {
           'unfurl_links' => $app['config']->get('slack::unfurl_links'),
           'unfurl_media' => is_bool($unfurl_media) ? $unfurl_media : true,
           'allow_markdown' => is_bool($allow_markdown) ? $allow_markdown : true,
-          'markdown_in_attachments' => is_array($markdown_in_attachments) ? $markdown_in_attachments : []
+          'markdown_in_attachments' => is_array($markdown_in_attachments) ? $markdown_in_attachments : [],
+          'is_slack_enabled' => is_bool($is_slack_enabled) ? $is_slack_enabled : true,
         ],
         $this->getQueue(),
         new Guzzle
       );
     });
 
-    $this->app->bind('Maknz\Slack\Client', 'maknz.slack');
+    $this->app->bind('Maknz\Slack\Client', 'slack');
   }
 
 }

--- a/src/SlackServiceProviderLaravel5.php
+++ b/src/SlackServiceProviderLaravel5.php
@@ -6,68 +6,60 @@ use Illuminate\Encryption\Encrypter as Encrypter;
 use Illuminate\Queue\Capsule\Manager as QueueManager;
 use Queue;
 
-class SlackServiceProviderLaravel5 extends ServiceProvider {
-
+class SlackServiceProviderLaravel5 extends ServiceProvider
+{
   /**
    * Bootstrap the application events.
    *
    * @return void
    */
-  public function boot()
-  {
-    $this->publishes([__DIR__ . '/config/config.php' => config_path('slack.php')]);
-  }
-
-  protected function getEncrypter()
-  {
-    return $this->app['encrypter'];
-  }
-
-  protected function getQueue()
-  {
-    $name = Queue::getFacadeRoot()->getDefaultDriver();
-
-    $config = $this->app['config']["queue.connections.{$name}"];
-
-    $queue = new QueueManager($this->app);
-
-    $queue->addConnection($config);
-
-    $queue->getContainer()->bind('Illuminate\Contracts\Encryption\Encrypter', 'encrypter');
-
-    return $queue;
-  }
-
-  /**
-   * Register the service provider.
-   *
-   * @return void
-   */
-  public function register()
-  {
-    $this->mergeConfigFrom(__DIR__ . '/config/config.php', 'slack');
-
-    $this->app['slack'] = $this->app->share(function($app)
+    public function boot()
     {
-      return new Client(
-        $app['config']->get('slack.endpoint'),
-        [
-          'channel' => $app['config']->get('slack.channel'),
-          'username' => $app['config']->get('slack.username'),
-          'icon' => $app['config']->get('slack.icon'),
-          'link_names' => $app['config']->get('slack.link_names'),
-          'unfurl_links' => $app['config']->get('slack.unfurl_links'),
-          'unfurl_media' => $app['config']->get('slack.unfurl_media'),
-          'allow_markdown' => $app['config']->get('slack.allow_markdown'),
-          'markdown_in_attachments' => $app['config']->get('slack.markdown_in_attachments'),
-          'is_slack_enabled' => $app['config']->get('slack.is_slack_enabled'),
-        ],
-        $this->getQueue(),
-        new Guzzle
-      );
-    });
+        $this->publishes([__DIR__ . '/config/config.php' => config_path('slack.php')]);
+    }
 
-    $this->app->bind('Maknz\Slack\Client', 'slack');
-  }
+    protected function getEncrypter()
+    {
+        return $this->app['encrypter'];
+    }
 
+    protected function getDefaultQueue()
+    {
+        $queue = $this->app['queue.connection'];
+
+        return $queue;
+    }
+
+    /**
+    * Register the service provider.
+    *
+    * @return void
+    */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__ . '/config/config.php', 'slack');
+
+        $this->app->singleton('slack', function ($app) {
+            $slack = new Client(
+                $app['config']->get('slack.endpoint'),
+                [
+                    'channel'                 => $app['config']->get('slack.channel'),
+                    'username'                => $app['config']->get('slack.username'),
+                    'icon'                    => $app['config']->get('slack.icon'),
+                    'link_names'              => $app['config']->get('slack.link_names'),
+                    'unfurl_links'            => $app['config']->get('slack.unfurl_links'),
+                    'unfurl_media'            => $app['config']->get('slack.unfurl_media'),
+                    'allow_markdown'          => $app['config']->get('slack.allow_markdown'),
+                    'markdown_in_attachments' => $app['config']->get('slack.markdown_in_attachments'),
+                    'is_slack_enabled'        => $app['config']->get('slack.is_slack_enabled'),
+                ],
+                $this->getDefaultQueue(),
+                new Guzzle
+            );
+
+            return $slack;
+        });
+
+        $this->app->bind('Maknz\Slack\Client', 'slack');
+    }
 }

--- a/src/SlackServiceProviderLaravel5.php
+++ b/src/SlackServiceProviderLaravel5.php
@@ -24,7 +24,7 @@ class SlackServiceProviderLaravel5 extends ServiceProvider {
   {
     $this->mergeConfigFrom(__DIR__ . '/config/config.php', 'slack');
 
-    $this->app['maknz.slack'] = $this->app->share(function($app)
+    $this->app['slack'] = $this->app->share(function($app)
     {
       return new Client(
         $app['config']->get('slack.endpoint'),
@@ -36,13 +36,14 @@ class SlackServiceProviderLaravel5 extends ServiceProvider {
           'unfurl_links' => $app['config']->get('slack.unfurl_links'),
           'unfurl_media' => $app['config']->get('slack.unfurl_media'),
           'allow_markdown' => $app['config']->get('slack.allow_markdown'),
-          'markdown_in_attachments' => $app['config']->get('slack.markdown_in_attachments')
+          'markdown_in_attachments' => $app['config']->get('slack.markdown_in_attachments'),
+          'is_slack_enabled' => $app['config']->get('slack.is_slack_enabled'),
         ],
         new Guzzle
       );
     });
     
-    $this->app->bind('Maknz\Slack\Client', 'maknz.slack');
+    $this->app->bind('Maknz\Slack\Client', 'slack');
   }
 
 }

--- a/src/SlackServiceProviderLaravel5.php
+++ b/src/SlackServiceProviderLaravel5.php
@@ -33,15 +33,6 @@ class SlackServiceProviderLaravel5 extends ServiceProvider {
 
     $queue->addConnection($config);
 
-    /*$queue->getContainer()->bind('encrypter', function(){
-      $key = '4dkTd5lWhN40CkSrnyrRBuRMsSX9exXD';
-      $encrypter = $this->getEncrypter();
-      return $encrypter($key);
-    });*/
-    //$queue->getContainer()->bind('encrypter', function(){
-    //        return $this->getEncrypter();
-    //});
-
     $queue->getContainer()->bind('Illuminate\Contracts\Encryption\Encrypter', 'encrypter');
 
     return $queue;

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -107,7 +107,7 @@ return [
   |
   | Which attachment fields should be interpreted in Slack's Markdown-like
   | language. By default, Slack assumes that no fields in an attachment
-  | should be formatted as Markdown. 
+  | should be formatted as Markdown.
   |
   */
 
@@ -118,5 +118,8 @@ return [
 
   // Allow Markdown in all fields
   // 'markdown_in_attachments' => ['pretext', 'text', 'title', 'fields', 'fallback']
+
+  // Team details
+  'team' => 'razorpay',
 
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -119,7 +119,4 @@ return [
   // Allow Markdown in all fields
   // 'markdown_in_attachments' => ['pretext', 'text', 'title', 'fields', 'fallback']
 
-  // Team details
-  'team' => 'razorpay',
-
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -119,4 +119,7 @@ return [
   // Allow Markdown in all fields
   // 'markdown_in_attachments' => ['pretext', 'text', 'title', 'fields', 'fallback']
 
+  //Slack enable/disable
+  'is_slack_enabled' => true,
+
 ];

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -4,158 +4,184 @@ use Maknz\Slack\Client;
 use Maknz\Slack\Attachment;
 use Maknz\Slack\AttachmentField;
 
-class AttachmentUnitTest extends PHPUnit_Framework_TestCase {
+class AttachmentUnitTest extends PHPUnit_Framework_TestCase
+{
+    public function testAttachmentCreationFromArray()
+    {
+        $a = new Attachment([
+            'fallback' => 'Fallback',
+            'text' => 'Text',
+            'pretext' => 'Pretext',
+            'color' => 'bad',
+            'mrkdwn_in' => ['pretext', 'text', 'fields']
+        ]);
 
-  public function testAttachmentCreationFromArray()
-  {
-    $a = new Attachment([
-      'fallback' => 'Fallback',
-      'text' => 'Text',
-      'pretext' => 'Pretext',
-      'color' => 'bad',
-      'mrkdwn_in' => ['pretext', 'text', 'fields']
-    ]);
+        $this->assertEquals('Fallback', $a->getFallback());
 
-    $this->assertEquals('Fallback', $a->getFallback());
+        $this->assertEquals('Text', $a->getText());
 
-    $this->assertEquals('Text', $a->getText());
+        $this->assertEquals('Pretext', $a->getPretext());
 
-    $this->assertEquals('Pretext', $a->getPretext());
+        $this->assertEquals('bad', $a->getColor());
 
-    $this->assertEquals('bad', $a->getColor());
+        $this->assertEquals([], $a->getFields());
 
-    $this->assertEquals([], $a->getFields());
+        $this->assertEquals(['pretext', 'text', 'fields'], $a->getMarkdownFields());
+    }
 
-    $this->assertEquals(['pretext', 'text', 'fields'], $a->getMarkdownFields());
-  }
+    public function testAttachmentCreationFromArrayWithFields()
+    {
+        $a = new Attachment([
+            'fallback' => 'Fallback',
+            'text' => 'Text',
+            'pretext' => 'Pretext',
+            'color' => 'bad',
+            'mrkdwn_in' => [],
+            'fields' => [
+            [
+              'title' => 'Title 1',
+              'value' => 'Value 1',
+              'short' => false
+            ],
+            [
+              'title' => 'Title 2',
+              'value' => 'Value 1',
+              'short' => false
+            ]
+            ]
+        ]);
 
-  public function testAttachmentCreationFromArrayWithFields()
-  {
-    $a = new Attachment([
-      'fallback' => 'Fallback',
-      'text' => 'Text',
-      'pretext' => 'Pretext',
-      'color' => 'bad',
-      'mrkdwn_in' => [],
-      'fields' => [
-        [
-          'title' => 'Title 1',
-          'value' => 'Value 1',
-          'short' => false
-        ],
-        [
-          'title' => 'Title 2',
-          'value' => 'Value 1',
-          'short' => false
-        ]
-      ]
-    ]);
+        $fields = $a->getFields();
 
-    $fields = $a->getFields();
+        $this->assertSame('Title 1', $fields[0]->getTitle());
 
-    $this->assertSame('Title 1', $fields[0]->getTitle());
+        $this->assertSame('Title 2', $fields[1]->getTitle());
+    }
 
-    $this->assertSame('Title 2', $fields[1]->getTitle());
-  }
+    public function testAttachmentToArray()
+    {
+        $array = [
+            'fallback' => 'Fallback',
+            'text' => 'Text',
+            'pretext' => 'Pretext',
+            'color' => 'bad',
+            'mrkdwn_in' => ['pretext', 'text'],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'title_link' => 'http://fake.host/',
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png',
+            'fields' => [
+                [
+                  'title' => 'Title 1',
+                  'value' => 'Value 1',
+                  'short' => false
+                ],
+                [
+                  'title' => 'Title 2',
+                  'value' => 'Value 1',
+                  'short' => false
+                ]
+            ]
+        ];
 
-  public function testAttachmentToArray()
-  {
-    $array = [
-      'fallback' => 'Fallback',
-      'text' => 'Text',
-      'pretext' => 'Pretext',
-      'color' => 'bad',
-      'mrkdwn_in' => ['pretext', 'text'],
-      'image_url' => 'http://fake.host/image.png',
-      'thumb_url' => 'http://fake.host/image.png',
-      'title' => 'A title',
-      'title_link' => 'http://fake.host/',
-      'author_name' => 'Joe Bloggs',
-      'author_link' => 'http://fake.host/',
-      'author_icon' => 'http://fake.host/image.png',
-      'fields' => [
-        [
-          'title' => 'Title 1',
-          'value' => 'Value 1',
-          'short' => false
-        ],
-        [
-          'title' => 'Title 2',
-          'value' => 'Value 1',
-          'short' => false
-        ]
-      ]
-    ];
+        $result = [
+            'fallback' => 'Fallback',
+            'text' => 'Text',
+            'pretext' => 'Pretext',
+            'color' => 'bad',
+            'mrkdwnIn' => ['pretext', 'text'],
+            'imageUrl' => 'http://fake.host/image.png',
+            'thumbUrl' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'titleLink' => 'http://fake.host/',
+            'authorName' => 'Joe Bloggs',
+            'authorLink' => 'http://fake.host/',
+            'authorIcon' => 'http://fake.host/image.png',
+            'fields' => [
+                [
+                  'title' => 'Title 1',
+                  'value' => 'Value 1',
+                  'short' => false
+                ],
+                [
+                  'title' => 'Title 2',
+                  'value' => 'Value 1',
+                  'short' => false
+                ]
+            ]
+        ];
 
-    $a = new Attachment($array);
+        $a = new Attachment($array);
 
-    $this->assertSame($array, $a->toArray());
-  }
+        $this->assertSame($result, $a->toArray());
+    }
 
-  public function testAddFieldAsArray()
-  {
-    $a = new Attachment([
-      'fallback' => 'Fallback',
-      'text' => 'Text'
-    ]);
+    public function testAddFieldAsArray()
+    {
+        $a = new Attachment([
+            'fallback' => 'Fallback',
+            'text' => 'Text'
+        ]);
 
-    $a->addField([
-      'title' => 'Title 1',
-      'value' => 'Value 1',
-      'short' => true
-    ]);
+        $a->addField([
+            'title' => 'Title 1',
+            'value' => 'Value 1',
+            'short' => true
+        ]);
 
-    $fields = $a->getFields();
+        $fields = $a->getFields();
 
-    $this->assertSame(1, count($fields));
+        $this->assertSame(1, count($fields));
 
-    $this->assertSame('Title 1', $fields[0]->getTitle());
-  }
+        $this->assertSame('Title 1', $fields[0]->getTitle());
+    }
 
-  public function testAddFieldAsObject()
-  {
-    $a = new Attachment([
-      'fallback' => 'Fallback',
-      'text' => 'Text'
-    ]);
+    public function testAddFieldAsObject()
+    {
+        $a = new Attachment([
+            'fallback' => 'Fallback',
+            'text' => 'Text'
+        ]);
 
-    $f = new AttachmentField([
-      'title' => 'Title 1',
-      'value' => 'Value 1',
-      'short' => true
-    ]);
+        $f = new AttachmentField([
+            'title' => 'Title 1',
+            'value' => 'Value 1',
+            'short' => true
+        ]);
 
-    $a->addField($f);
+        $a->addField($f);
 
-    $fields = $a->getFields();
+        $fields = $a->getFields();
 
-    $this->assertSame(1, count($fields));
+        $this->assertSame(1, count($fields));
 
-    $this->assertSame($f, $fields[0]);
-  }
+        $this->assertSame($f, $fields[0]);
+    }
 
-  public function testSetFields()
-  {
-    $a = new Attachment([
-      'fallback' => 'Fallback',
-      'text' => 'Text'
-    ]);
+    public function testSetFields()
+    {
+        $a = new Attachment([
+            'fallback' => 'Fallback',
+            'text' => 'Text'
+        ]);
 
-    $a->addField([
-      'title' => 'Title 1',
-      'value' => 'Value 1',
-      'short' => true
-    ])->addField([
-      'title' => 'Title 2',
-      'value' => 'Value 2',
-      'short' => true
-    ]);
+        $a->addField([
+            'title' => 'Title 1',
+            'value' => 'Value 1',
+            'short' => true
+        ])->addField([
+            'title' => 'Title 2',
+            'value' => 'Value 2',
+            'short' => true
+        ]);
 
-    $this->assertSame(2, count($a->getFields()));
+        $this->assertSame(2, count($a->getFields()));
 
-    $a->setFields([]);
+        $a->setFields([]);
 
-    $this->assertSame(0, count($a->getFields()));
-  }
-
+        $this->assertSame(0, count($a->getFields()));
+    }
 }

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -4,165 +4,171 @@ use Maknz\Slack\Client;
 use Maknz\Slack\Attachment;
 use Illuminate\Queue\Capsule\Manager as Queue;
 
-class ClientFunctionalTest extends PHPUnit_Framework_TestCase {
+class ClientFunctionalTest extends PHPUnit_Framework_TestCase
+{
+    public function testPlainMessage()
+    {
+        $expectedHttpData = [
+            'username' => 'Archer',
+            'channel' => '@regan',
+            'text' => 'Message',
+            'link_names' => false,
+            'unfurl_links' => false,
+            'unfurl_media' => true,
+            'mrkdwn' => true,
+            'attachments' => []
+        ];
 
-  public function testPlainMessage()
-  {
-    $expectedHttpData = [
-      'username' => 'Archer',
-      'channel' => '@regan',
-      'text' => 'Message',
-      'link_names' => false,
-      'unfurl_links' => false,
-      'unfurl_media' => true,
-      'mrkdwn' => true,
-      'attachments' => []
-    ];
+        $client = new Client('http://fake.endpoint');
 
-    $client = new Client('http://fake.endpoint');
+        $message = $client->to('@regan')->from('Archer')->setText('Message');
 
-    $message = $client->to('@regan')->from('Archer')->setText('Message');
+        $payload = $client->preparePayload($message);
 
-    $payload = $client->preparePayload($message);
+        $this->assertEquals($expectedHttpData, $payload);
+    }
 
-    $this->assertEquals($expectedHttpData, $payload);
-  }
+    public function testMessageWithAttachments()
+    {
+        $attachmentArray = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'mrkdwn_in' => ['pretext', 'text'],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'fields' => [],
+            'title' => null,
+            'title_link' => null,
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png'
+        ];
 
-  public function testMessageWithAttachments()
-  {
-    $attachmentArray = [
-      'fallback' => 'Some fallback text',
-      'text' => 'Some text to appear in the attachment',
-      'pretext' => null,
-      'color' => 'bad',
-      'mrkdwn_in' => ['pretext', 'text'],
-      'image_url' => 'http://fake.host/image.png',
-      'thumb_url' => 'http://fake.host/image.png',
-      'fields' => [],
-      'title' => null,
-      'title_link' => null,
-      'author_name' => 'Joe Bloggs',
-      'author_link' => 'http://fake.host/',
-      'author_icon' => 'http://fake.host/image.png'
-    ];
+        $attachmentResult = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'mrkdwnIn' => ['pretext', 'text'],
+            'imageUrl' => 'http://fake.host/image.png',
+            'thumbUrl' => 'http://fake.host/image.png',
+            'fields' => [],
+            'title' => null,
+            'titleLink' => null,
+            'authorName' => 'Joe Bloggs',
+            'authorLink' => 'http://fake.host/',
+            'authorIcon' => 'http://fake.host/image.png'
+        ];
 
-    $expectedHttpData = [
-      'username' => 'Test',
-      'channel' => '#general',
-      'text' => 'Message',
-      'link_names' => false,
-      'unfurl_links' => false,
-      'unfurl_media' => true,
-      'mrkdwn' => true,
-      'attachments' => [$attachmentArray]
-    ];
+        $expectedHttpData = [
+            'username' => 'Test',
+            'channel' => '#general',
+            'text' => 'Message',
+            'link_names' => 0,
+            'unfurl_links' => false,
+            'unfurl_media' => true,
+            'mrkdwn' => true,
+            'attachments' => [$attachmentResult]
+        ];
 
-    $client = new Client('http://fake.endpoint', [
-      'username' => 'Test',
-      'channel' => '#general'
-    ]);
+        $client = new Client('http://fake.endpoint', [
+            'username' => 'Test',
+            'channel' => '#general'
+        ]);
 
-    $message = $client->createMessage()->setText('Message');
+        $message = $client->createMessage()->setText('Message');
 
-    $attachment = new Attachment($attachmentArray);
+        $attachment = new Attachment($attachmentArray);
 
-    $message->attach($attachment);
+        $message->attach($attachment);
 
-    $payload = $client->preparePayload($message);
+        $payload = $client->preparePayload($message);
 
-    $this->assertEquals($expectedHttpData, $payload);
-  }
+        $this->assertEquals($expectedHttpData, $payload);
+    }
 
-  public function testMessageWithAttachmentsAndFields()
-  {
-    $attachmentArray = [
-      'fallback' => 'Some fallback text',
-      'text' => 'Some text to appear in the attachment',
-      'pretext' => null,
-      'color' => 'bad',
-      'mrkdwn_in' => [],
-      'image_url' => 'http://fake.host/image.png',
-      'thumb_url' => 'http://fake.host/image.png',
-      'title' => 'A title',
-      'title_link' => 'http://fake.host/',
-      'author_name' => 'Joe Bloggs',
-      'author_link' => 'http://fake.host/',
-      'author_icon' => 'http://fake.host/image.png',
-      'fields' => [
-        [
-          'title' => 'Field 1',
-          'value' => 'Value 1',
-          'short' => false
-        ],
-        [
-          'title' => 'Field 2',
-          'value' => 'Value 2',
-          'short' => false
-        ]
-      ]
-    ];
+    public function testMessageWithAttachmentsAndFields()
+    {
+        $attachmentArray = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'mrkdwn_in' => [],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'title_link' => 'http://fake.host/',
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png',
+            'fields' => [
+                [
+                    'title' => 'Field 1',
+                    'value' => 'Value 1',
+                    'short' => false
+                ],
+                [
+                    'title' => 'Field 2',
+                    'value' => 'Value 2',
+                    'short' => false
+                ]
+            ]
+        ];
 
-    $expectedHttpData = [
-      'username' => 'Test',
-      'channel' => '#general',
-      'text' => 'Message',
-      'link_names' => false,
-      'unfurl_links' => false,
-      'unfurl_media' => true,
-      'mrkdwn' => true,
-      'attachments' => [$attachmentArray]
-    ];
+        $attachmentResult = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'mrkdwnIn' => [],
+            'imageUrl' => 'http://fake.host/image.png',
+            'thumbUrl' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'titleLink' => 'http://fake.host/',
+            'authorName' => 'Joe Bloggs',
+            'authorLink' => 'http://fake.host/',
+            'authorIcon' => 'http://fake.host/image.png',
+            'fields' => [
+                [
+                    'title' => 'Field 1',
+                    'value' => 'Value 1',
+                    'short' => false
+                ],
+                [
+                    'title' => 'Field 2',
+                    'value' => 'Value 2',
+                    'short' => false
+                ]
+            ]
+        ];
 
-    $client = new Client('http://fake.endpoint', [
-      'username' => 'Test',
-      'channel' => '#general'
-    ]);
+        $expectedHttpData = [
+            'username' => 'Test',
+            'channel' => '#general',
+            'text' => 'Message',
+            'link_names' => 0,
+            'unfurl_links' => false,
+            'unfurl_media' => true,
+            'mrkdwn' => true,
+            'attachments' => [$attachmentResult]
+        ];
 
-    $message = $client->createMessage()->setText('Message');
+        $client = new Client('http://fake.endpoint', [
+            'username' => 'Test',
+            'channel' => '#general'
+        ]);
 
-    $attachment = new Attachment($attachmentArray);
+        $message = $client->createMessage()->setText('Message');
 
-    $message->attach($attachment);
+        $attachment = new Attachment($attachmentArray);
 
-    $payload = $client->preparePayload($message);
+        $message->attach($attachment);
 
-    $this->assertEquals($expectedHttpData, $payload);
-  }
+        $payload = $client->preparePayload($message);
 
-  public function testSendQueue()
-  {
-    $queue = Mockery::mock('Illuminate\Queue\Capsule\Manager[push]')->makePartial('push');
-    $guzzle = Mockery::mock('GuzzleHttp\Client[post]')->makePartial('post');
-
-    $queue->getContainer()->bind('encrypter', function(){
-      return new Illuminate\Encryption\Encrypter('slack');
-    });
-
-    $queue->addConnection(['driver' => 'sync']);
-
-    $expectedHttpData = [
-      'text' => 'Message',
-      'channel' => '#general',
-      'username' => 'Test',
-      'link_names' => 0,
-      'unfurl_links' => false,
-      'unfurl_media' => true,
-      'mrkdwn' => true,
-      'attachments' => []
-    ];
-
-    $client = new Client('http://fake.endpoint', [
-      'username' => 'Test',
-      'channel' => '#general'
-    ], $queue, $guzzle);
-
-    $guzzle->shouldReceive('post')->withArgs(['http://fake.endpoint', $expectedHttpData]);
-    $queue->shouldReceive('push')->withArgs(['Maknz\Slack\Client', $expectedHttpData]);
-    $this->assertSame($queue, $client->getQueueManager());
-
-    $message = $client->createMessage()->setText('Message');
-    $client->queueMessage($message);
-
-  }
-
+        $this->assertEquals($expectedHttpData, $payload);
+    }
 }

--- a/tests/ClientUnitTest.php
+++ b/tests/ClientUnitTest.php
@@ -1,96 +1,94 @@
 <?php
 
 use Maknz\Slack\Client;
-use Illuminate\Queue\Capsule\Manager as Queue;
+use Illuminate\Queue\SyncQueue as Queue;
 
-class ClientUnitTest extends PHPUnit_Framework_TestCase {
+class ClientUnitTest extends PHPUnit_Framework_TestCase
+{
+    public function testInstantiationWithNoDefaults()
+    {
+        $client = new Client('http://fake.endpoint');
 
-  public function testInstantiationWithNoDefaults()
-  {
-    $client = new Client('http://fake.endpoint');
+        $this->assertInstanceOf('Maknz\Slack\Client', $client);
 
-    $this->assertInstanceOf('Maknz\Slack\Client', $client);
+        $this->assertSame('http://fake.endpoint', $client->getEndpoint());
 
-    $this->assertSame('http://fake.endpoint', $client->getEndpoint());
+        $this->assertNull($client->getQueueManager());
+    }
 
-    $this->assertNull($client->getQueueManager());
-  }
+    public function testInstantiationWithDefaults()
+    {
+        $defaults = [
+            'channel' => '#random',
+            'username' => 'Archer',
+            'icon' => ':ghost:',
+            'link_names' => true,
+            'unfurl_links' => true,
+            'unfurl_media' => false,
+            'allow_markdown' => false,
+            'markdown_in_attachments' => ['text'],
+            'is_slack_enabled' => false
+        ];
 
-  public function testInstantiationWithDefaults()
-  {
-    $defaults = [
-      'channel' => '#random',
-      'username' => 'Archer',
-      'icon' => ':ghost:',
-      'link_names' => true,
-      'unfurl_links' => true,
-      'unfurl_media' => false,
-      'allow_markdown' => false,
-      'markdown_in_attachments' => ['text'],
-      'is_slack_enabled' => false
-    ];
+        $client = new Client('http://fake.endpoint', $defaults);
 
-    $client = new Client('http://fake.endpoint', $defaults);
+        $this->assertSame($defaults['channel'], $client->getDefaultChannel());
 
-    $this->assertSame($defaults['channel'], $client->getDefaultChannel());
+        $this->assertSame($defaults['username'], $client->getDefaultUsername());
 
-    $this->assertSame($defaults['username'], $client->getDefaultUsername());
+        $this->assertSame($defaults['icon'], $client->getDefaultIcon());
 
-    $this->assertSame($defaults['icon'], $client->getDefaultIcon());
+        $this->assertTrue($client->getLinkNames());
 
-    $this->assertTrue($client->getLinkNames());
+        $this->assertTrue($client->getUnfurlLinks());
 
-    $this->assertTrue($client->getUnfurlLinks());
+        $this->assertFalse($client->getUnfurlMedia());
 
-    $this->assertFalse($client->getUnfurlMedia());
+        $this->assertSame($defaults['allow_markdown'], $client->getAllowMarkdown());
 
-    $this->assertSame($defaults['allow_markdown'], $client->getAllowMarkdown());
+        $this->assertSame($defaults['markdown_in_attachments'], $client->getMarkdownInAttachments());
 
-    $this->assertSame($defaults['markdown_in_attachments'], $client->getMarkdownInAttachments());
+        $this->assertFalse($client->getSlackStatus());
+    }
 
-    $this->assertFalse($client->getSlackStatus());
+    public function testInstantiationWithQueue()
+    {
+        $queue = new Queue;
 
-  }
+        $client = new Client('http://fake.endpoing', [], $queue);
 
-  public function testInstantiationWithQueue()
-  {
-    $queue = new Queue;
+        $this->assertInstanceOf('Illuminate\Contracts\Queue\Queue', $client->getQueue());
+    }
 
-    $client = new Client('http://fake.endpoing', [], $queue);
+    public function testCreateMessage()
+    {
+        $defaults = [
+            'channel' => '#random',
+            'username' => 'Archer',
+            'icon' => ':ghost:'
+        ];
 
-    $this->assertInstanceOf('Illuminate\Queue\Capsule\Manager', $client->getQueueManager());
-  }
+        $client = new Client('http://fake.endpoint', $defaults);
 
-  public function testCreateMessage()
-  {
-    $defaults = [
-      'channel' => '#random',
-      'username' => 'Archer',
-      'icon' => ':ghost:'
-    ];
+        $message = $client->createMessage();
 
-    $client = new Client('http://fake.endpoint', $defaults);
+        $this->assertInstanceOf('Maknz\Slack\Message', $message);
 
-    $message = $client->createMessage();
+        $this->assertSame($client->getDefaultChannel(), $message->getChannel());
 
-    $this->assertInstanceOf('Maknz\Slack\Message', $message);
+        $this->assertSame($client->getDefaultUsername(), $message->getUsername());
 
-    $this->assertSame($client->getDefaultChannel(), $message->getChannel());
+        $this->assertSame($client->getDefaultIcon(), $message->getIcon());
+    }
 
-    $this->assertSame($client->getDefaultUsername(), $message->getUsername());
+    public function testWildcardCallToMessage()
+    {
+        $client = new Client('http://fake.endpoint');
 
-    $this->assertSame($client->getDefaultIcon(), $message->getIcon());
-  }
+        $message = $client->to('@regan');
 
-  public function testWildcardCallToMessage()
-  {
-    $client = new Client('http://fake.endpoint');
+        $this->assertInstanceOf('Maknz\Slack\Message', $message);
 
-    $message = $client->to('@regan');
-
-    $this->assertInstanceOf('Maknz\Slack\Message', $message);
-
-    $this->assertSame('@regan', $message->getChannel());
-  }
-
+        $this->assertSame('@regan', $message->getChannel());
+    }
 }

--- a/tests/ClientUnitTest.php
+++ b/tests/ClientUnitTest.php
@@ -26,7 +26,8 @@ class ClientUnitTest extends PHPUnit_Framework_TestCase {
       'unfurl_links' => true,
       'unfurl_media' => false,
       'allow_markdown' => false,
-      'markdown_in_attachments' => ['text']
+      'markdown_in_attachments' => ['text'],
+      'is_slack_enabled' => false
     ];
 
     $client = new Client('http://fake.endpoint', $defaults);
@@ -46,6 +47,9 @@ class ClientUnitTest extends PHPUnit_Framework_TestCase {
     $this->assertSame($defaults['allow_markdown'], $client->getAllowMarkdown());
 
     $this->assertSame($defaults['markdown_in_attachments'], $client->getMarkdownInAttachments());
+
+    $this->assertFalse($client->getSlackStatus());
+
   }
 
   public function testInstantiationWithQueue()

--- a/tests/MessageUnitTest.php
+++ b/tests/MessageUnitTest.php
@@ -4,195 +4,186 @@ use Maknz\Slack\Client;
 use Maknz\Slack\Message;
 use Maknz\Slack\Attachment;
 
-class MessageUnitTest extends PHPUnit_Framework_TestCase {
+class MessageUnitTest extends PHPUnit_Framework_TestCase
+{
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf('Maknz\Slack\Message', $this->getMessage());
+    }
 
-  public function testInstantiation()
-  {
-    $this->assertInstanceOf('Maknz\Slack\Message', $this->getMessage());
-  }
+    public function testSetText()
+    {
+        $message = $this->getMessage();
 
-  public function testSetText()
-  {
-    $message = $this->getMessage();
+        $message->setText('Hello world');
 
-    $message->setText('Hello world');
+        $this->assertSame('Hello world', $message->getText());
+    }
 
-    $this->assertSame('Hello world', $message->getText());
-  }
+    public function testSetChannelWithTo()
+    {
+        $message = $this->getMessage();
 
-  public function testSetChannelWithTo()
-  {
-    $message = $this->getMessage();
+        $message->to('#php');
 
-    $message->to('#php');
+        $this->assertSame('#php', $message->getChannel());
+    }
 
-    $this->assertSame('#php', $message->getChannel());
-  }
+    public function testSetChannelWithSetter()
+    {
+        $message = $this->getMessage();
 
-  public function testSetChannelWithSetter()
-  {
-    $message = $this->getMessage();
+        $message->setChannel('#php');
 
-    $message->setChannel('#php');
+        $this->assertSame('#php', $message->getChannel());
+    }
 
-    $this->assertSame('#php', $message->getChannel());
-  }
+    public function testSetUsernameWithFrom()
+    {
+        $message = $this->getMessage();
 
-  public function testSetUsernameWithFrom()
-  {
-    $message = $this->getMessage();
+        $message->from('Archer');
 
-    $message->from('Archer');
+        $this->assertSame('Archer', $message->getUsername());
+    }
 
-    $this->assertSame('Archer', $message->getUsername());
-  }
+    public function testSetUsernameWithSetter()
+    {
+        $message = $this->getMessage();
 
-  public function testSetUsernameWithSetter()
-  {
-    $message = $this->getMessage();
+        $message->setUsername('Archer');
 
-    $message->setUsername('Archer');
+        $this->assertSame('Archer', $message->getUsername());
+    }
 
-    $this->assertSame('Archer', $message->getUsername());
-  }
+    public function testAttachWithArray()
+    {
+        $message = $this->getMessage();
 
-  public function testAttachWithArray()
-  {
-    $message = $this->getMessage();
+        $attachmentArray = [
+            'fallback' => 'Fallback text for IRC',
+            'text' => 'Attachment text',
+            'pretext' => 'Attachment pretext',
+            'color' => 'bad',
+            'fields' => []
+        ];
 
-    $attachmentArray = [
-      'fallback' => 'Fallback text for IRC',
-      'text' => 'Attachment text',
-      'pretext' => 'Attachment pretext',
-      'color' => 'bad',
-      'fields' => []
-    ];
+        $message->attach($attachmentArray);
 
-    $message->attach($attachmentArray);
+        $attachments = $message->getAttachments();
 
-    $attachments = $message->getAttachments();
+        $this->assertEquals(1, count($attachments));
 
-    $this->assertEquals(1, count($attachments));
+        $obj = $attachments[0];
 
-    $obj = $attachments[0];
+        $this->assertEquals($attachmentArray['fallback'], $obj->getFallback());
 
-    $this->assertEquals($attachmentArray['fallback'], $obj->getFallback());
+        $this->assertEquals($attachmentArray['text'], $obj->getText());
 
-    $this->assertEquals($attachmentArray['text'], $obj->getText());
+        $this->assertEquals($attachmentArray['pretext'], $obj->getPretext());
 
-    $this->assertEquals($attachmentArray['pretext'], $obj->getPretext());
+        $this->assertEquals($attachmentArray['color'], $obj->getColor());
+    }
 
-    $this->assertEquals($attachmentArray['color'], $obj->getColor());
-  }
+    public function testAttachWithObject()
+    {
+        $message = $this->getMessage();
 
-  public function testAttachWithObject()
-  {
-    $message = $this->getMessage();
+        $obj = new Attachment([
+            'fallback' => 'Fallback text for IRC',
+            'text' => 'Text'
+        ]);
 
-    $obj = new Attachment([
-      'fallback' => 'Fallback text for IRC',
-      'text' => 'Text'
-    ]);
+        $message->attach($obj);
 
-    $message->attach($obj);
+        $attachments = $message->getAttachments();
 
-    $attachments = $message->getAttachments();
+        $this->assertEquals(1, count($attachments));
 
-    $this->assertEquals(1, count($attachments));
+        $remoteObj = $attachments[0];
 
-    $remoteObj = $attachments[0];
+        $this->assertEquals($obj, $remoteObj);
+    }
 
-    $this->assertEquals($obj, $remoteObj);
-  }
+    public function testMultipleAttachments()
+    {
+        $message = $this->getMessage();
 
-  public function testMultipleAttachments()
-  {
-    $message = $this->getMessage();
+        $obj1 = new Attachment([
+            'fallback' => 'Fallback text for IRC',
+            'text' => 'Text'
+        ]);
 
-    $obj1 = new Attachment([
-      'fallback' => 'Fallback text for IRC',
-      'text' => 'Text'
-    ]);
+        $obj2 = new Attachment([
+            'fallback' => 'Fallback text for IRC',
+            'text' => 'Text'
+        ]);
 
-    $obj2 = new Attachment([
-      'fallback' => 'Fallback text for IRC',
-      'text' => 'Text'
-    ]);
+        $message->attach($obj1)->attach($obj2);
 
-    $message->attach($obj1)->attach($obj2);
+        $attachments = $message->getAttachments();
 
-    $attachments = $message->getAttachments();
+        $this->assertEquals(2, count($attachments));
 
-    $this->assertEquals(2, count($attachments));
+        $remote1 = $attachments[0];
 
-    $remote1 = $attachments[0];
+        $remote2 = $attachments[1];
 
-    $remote2 = $attachments[1];
+        $this->assertEquals($obj1, $remote1);
 
-    $this->assertEquals($obj1, $remote1);
+        $this->assertEquals($obj2, $remote2);
+    }
 
-    $this->assertEquals($obj2, $remote2);
-  }
+    public function testSetAttachmentsWipesExistingAttachments()
+    {
+        $message = $this->getMessage();
 
-  public function testSetAttachmentsWipesExistingAttachments()
-  {
-    $message = $this->getMessage();
+        $obj1 = new Attachment([
+            'fallback' => 'Fallback text for IRC',
+            'text' => 'Text'
+        ]);
 
-    $obj1 = new Attachment([
-      'fallback' => 'Fallback text for IRC',
-      'text' => 'Text'
-    ]);
+        $obj2 = new Attachment([
+            'fallback' => 'Fallback text for IRC',
+            'text' => 'Text'
+        ]);
 
-    $obj2 = new Attachment([
-      'fallback' => 'Fallback text for IRC',
-      'text' => 'Text'
-    ]);
+        $message->attach($obj1)->attach($obj2);
 
-    $message->attach($obj1)->attach($obj2);
+        $this->assertEquals(2, count($message->getAttachments()));
 
-    $this->assertEquals(2, count($message->getAttachments()));
+        $message->setAttachments([['fallback' => 'a', 'text' => 'b']]);
 
-    $message->setAttachments([['fallback' => 'a', 'text' => 'b']]);
+        $this->assertEquals(1, count($message->getAttachments()));
 
-    $this->assertEquals(1, count($message->getAttachments()));
+        $this->assertEquals('a', $message->getAttachments()[0]->getFallback());
+    }
 
-    $this->assertEquals('a', $message->getAttachments()[0]->getFallback());
-  }
+    public function testSetIconToEmoji()
+    {
+        $message = $this->getMessage();
 
-  public function testSetIconToEmoji()
-  {
-    $message = $this->getMessage();
+        $message->setIcon(':ghost:');
 
-    $message->setIcon(':ghost:');
+        $this->assertEquals(Message::ICON_TYPE_EMOJI, $message->getIconType());
 
-    $this->assertEquals(Message::ICON_TYPE_EMOJI, $message->getIconType());
+        $this->assertEquals(':ghost:', $message->getIcon());
+    }
 
-    $this->assertEquals(':ghost:', $message->getIcon());
-  }
+    public function testSetIconToUrl()
+    {
+        $message = $this->getMessage();
 
-  public function testSetIconToUrl()
-  {
-    $message = $this->getMessage();
+        $message->setIcon('http://www.fake.com/someimage.png');
 
-    $message->setIcon('http://www.fake.com/someimage.png');
+        $this->assertEquals(Message::ICON_TYPE_URL, $message->getIconType());
 
-    $this->assertEquals(Message::ICON_TYPE_URL, $message->getIconType());
+        $this->assertEquals('http://www.fake.com/someimage.png', $message->getIcon());
+    }
 
-    $this->assertEquals('http://www.fake.com/someimage.png', $message->getIcon());
-  }
-
-  public function testSetQueue()
-  {
-    $message = $this->getMessage();
-
-    $message->setQueue('slack');
-
-    $this->assertSame('slack', $message->getQueue());
-  }
-
-  protected function getMessage()
-  {
-    return new Message(Mockery::mock('Maknz\Slack\Client'));
-  }
+    protected function getMessage()
+    {
+        return new Message(Mockery::mock('Maknz\Slack\Client'));
+    }
 
 }


### PR DESCRIPTION
The current implementation adds support to handle retry for both synchronous(send) and asynchronous(queue) calls. The client can now send the number of times to retry before giving up on a given job(posting a message to slack). By default, the message is tried MAX_RETRY_ATTEMPTS times along with the wait time before pushing the job back to the queue. After MAX_RETRY_ATTEMPS, the job gets deleted. Similarly, for send again, the job can get tried a number of times beyond which the message is pushed to the queue for further retry again following the same process. 

Additionally, there is a pass through mode enabled for slack notifications(is_slack_enabled) which allows the client to test the functionality by mocking the notifications.
