### PR TITLE
Don't use __CLASS__ to push job into the queue

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -484,7 +484,7 @@ class Client
 
         $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE);
 
-        $this->queue->push(__CLASS__, $payload, $queue);
+        $this->queue->push(static::class, $payload, $queue);
     }
 
     /**


### PR DESCRIPTION
This causes inheritance issues when extending the class and can break a
queue job. Using `static::class` will ensure that the child class name
is always used for the job payload.