### PR TITLE
Move queue from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": ">=5.5.0",
         "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "illuminate/queue":"5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",
         "mockery/mockery": "0.9.*",
-        "illuminate/queue":"5.*",
         "satooshi/php-coveralls": "~1.0"
     },
     "suggest": {


### PR DESCRIPTION
Since `Client.php` uses `DispatchesJobs` the `illuminate/queue` package should be required for everyone, not just dev. Right now if you install `razorpay/slack` as a dependency to another project composer won't automatically install that package.