### PR TITLE
[travis] Trusty for Travis

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6
   - 7.0
   - 7.1.0a1
   - hhvm
-  
+
 matrix:
   allow_failures:
     - php: 7.1.0a1


### PR DESCRIPTION
- HHVM was failing on master for Ubuntu precise, ref: [failed build](https://github.com/travis-ci/travis-ci/issues/7712). Moved to Travis Trusty. Works now: [here you go](https://travis-ci.org/razorpay/slack/builds/259935444)
- Adds editorconfig
- Ignore build dir

