### PR TITLE
bugfix: build AttachmentAction without confirm

### DIFF
--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -226,13 +226,15 @@ class AttachmentAction
      */
     public function toArray()
     {
+        $confirm = $this->getConfirm();
+
         return [
             'name'    => $this->getName(),
             'text'    => $this->getText(),
             'style'   => $this->getStyle(),
             'type'    => $this->getType(),
             'value'   => $this->getValue(),
-            'confirm' => $this->getConfirm()->toArray(),
+            'confirm' => $confirm ? $confirm->toArray() : null,
         ];
     }
 }


### PR DESCRIPTION
now it produce `Call to a member function toArray() on a non-object`
& no way to send AttachmentAction without confirm.
see: https://github.com/maknz/slack/issues/61#issuecomment-230882072