### PR TITLE
Allow buttons to not require a confirmation object/array

### DIFF
--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -232,7 +232,7 @@ class AttachmentAction
             'style'   => $this->getStyle(),
             'type'    => $this->getType(),
             'value'   => $this->getValue(),
-            'confirm' => $this->getConfirm()->toArray(),
+            'confirm' => $this->getConfirm() ? $this->getConfirm()->toArray() : [],
         ];
     }
 }


### PR DESCRIPTION
Removes requirement for action confirmation. If no confirmation is specified then the call to toArray() fails.